### PR TITLE
Seperates the release gh-action into seperate jobs

### DIFF
--- a/.github/workflows/code_quality_ci.yml
+++ b/.github/workflows/code_quality_ci.yml
@@ -18,7 +18,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
           level: warning
-  alex: # Checks docs for inconsiderate writing
+  alex: # NOTE: Checks code for inconsiderate writing
     name: runner / alex
     runs-on: ubuntu-latest
     steps:
@@ -28,7 +28,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-check
           level: warning
-  markdown-lint:
+  markdown-lint: # NOTE: Checks markdown code and creates pull request if needed
     name: runner / remark-lint
     runs-on: ubuntu-latest
     steps:
@@ -65,7 +65,7 @@ jobs:
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-  black: # Check python code format
+  black: # NOTE: Checks python code and creates pull request if needed
     name: runner / black
     runs-on: ubuntu-latest
     steps:
@@ -102,7 +102,7 @@ jobs:
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-  flake8: # Lints python code
+  flake8: # NOTE: Lints python code to see if there are any errors
     name: runner / flake8
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -12,10 +12,11 @@ on:
     types:
       - labeled
 jobs:
-  release:
+  tag-release:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
+      # NOTE: Makes sure the new version also contains the right major and minor tags.
       - uses: actions/checkout@v2
       # Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
@@ -28,17 +29,18 @@ jobs:
         if: "!steps.bumpr.outputs.skip"
         with:
           tag: ${{ steps.bumpr.outputs.next_version }}
-  version-check:
+  version-release:
     if: github.event.action != 'labeled'
+    needs: tag-release
     runs-on: ubuntu-latest
     steps:
-      # NOTE: Fix detached head state when triggered on tag such that we can commit changes
+      # NOTE: Updates the version that is specified in the code files.
       - name: Check if triggered by tag or by label
         id: get_ref
         uses: haya14busa/action-cond@v1
         with:
           cond: "${{ !startsWith(github.ref, 'refs/tags/') }}"
-          if_true: ${{ github.ref }}
+          if_true: ${{ github.ref }} # Fix detached head
           if_false: "main"
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -77,10 +79,12 @@ jobs:
         with:
           branch: ${{ steps.get_ref.outputs.value }}
           commit_message: ":bookmark: Updates documentation version to ${{ steps.get_setmver.outputs.current_version }}"
-  changelog-check:
+  changelog-release:
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
+    needs: tag-release
     steps:
+      # NOTE: Makes sure the changelog is up to date.
       - name: Check if triggered by tag or by label
         id: get_ref
         uses: haya14busa/action-cond@v1
@@ -107,8 +111,10 @@ jobs:
           branch: ${{ steps.get_ref.outputs.value }}
           commit_message: ":memo: Updates CHANGELOG.md"
   create-pre-release:
+    # NOTE: Creates a pre-release for the tag
     if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
+    needs: tag-release
     steps:
       - uses: actions/checkout@v2
       - name: Build release changelog
@@ -127,6 +133,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   release-check:
+    # NOTE: Used to check if the bump:version label is working
     if: github.event.action == 'labeled'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request separates the release GitHub action into seperate jobs.