### PR TITLE
:green_heart: Adds autotag on labeled pull request gh-action

### DIFF
--- a/.github/workflows/autotag_ci.yml
+++ b/.github/workflows/autotag_ci.yml
@@ -1,0 +1,36 @@
+# This github action creates a new semver tag if a pull request is merged with specific
+# labels.
+name: release
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - labeled
+jobs:
+  release:
+    if: github.event.action != 'labeled'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      # Bump version on merging Pull Requests with specific labels.
+      # (bump:major,bump:minor,bump:patch)
+      - id: bumpr
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        uses: haya14busa/action-bumpr@v1
+
+      # Update corresponding major and minor tag.
+      # e.g. Update v1 and v1.2 when releasing v1.2.3
+      - uses: haya14busa/action-update-semver@v1
+        if: "!steps.bumpr.outputs.skip"
+        with:
+          tag: ${{ steps.bumpr.outputs.next_version }}
+  release-check:
+    if: github.event.action == 'labeled'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Post bumpr status comment
+        uses: haya14busa/action-bumpr@v1

--- a/.github/workflows/release_ci.yml
+++ b/.github/workflows/release_ci.yml
@@ -4,14 +4,14 @@ name: MLC release CI
 on:
   push:
     tags:
-      - "v*.*.*"
+      - v*.*.*
   pull_request:
     types:
       - labeled
 jobs:
   add-labeled-tag:
     runs-on: ubuntu-latest
-    if: "github.event.action != 'labeled'"
+    if: github.event.action != 'labeled'
     steps:
       # NOTE: Bump version on merging Pull Requests with specific labels.
       # (bump:major,bump:minor,bump:patch)
@@ -22,7 +22,7 @@ jobs:
   update-code-version:
     runs-on: ubuntu-latest
     needs: add-labeled-tag
-    if: "github.event.action != 'labeled'"
+    if: github.event.action != 'labeled'
     steps:
       # NOTE: Updates the version that is specified in the code files.
       - name: Checkout repository
@@ -66,7 +66,7 @@ jobs:
   release-changelog:
     runs-on: ubuntu-latest
     needs: update-code-version
-    if: "github.event.action != 'labeled'"
+    if: github.event.action != 'labeled'
     steps:
       # NOTE: Makes sure the changelog is up to date.
       - name: Checkout repository
@@ -88,10 +88,10 @@ jobs:
         with:
           branch: main
           commit_message: ":memo: Updates CHANGELOG.md"
-  update-major-minor-version-tags:
+  move-semver-tags:
     runs-on: ubuntu-latest
     needs: release-changelog
-    if: "github.event.action != 'labeled'"
+    if: github.event.action != 'labeled'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -110,8 +110,8 @@ jobs:
   create-pre-release:
     # NOTE: Creates a pre-release for the new tag
     runs-on: ubuntu-latest
-    needs: update-major-minor-version-tags
-    if: "github.event.action != 'labeled'"
+    needs: move-semver-tags
+    if: github.event.action != 'labeled'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
This pull request adds an action that automatically tags a new version based on the `bump:patch`, `bump:minor` and `bump:major` lables. It uses https://github.com/haya14busa/action-bumpr to do this.