### PR TITLE
refactor: replace 'verbose' with 'quiet'.

### DIFF
--- a/docs/source/usage/eval_robustness.rst
+++ b/docs/source/usage/eval_robustness.rst
@@ -37,7 +37,7 @@ The robustness evaluation tool can save several files to disk that contain infor
 |``figures/``           | | A directory containing the robustness evaluation plots when the  |
 |                       | | ``--save_figs`` flag was used.                                   |
 +-----------------------+--------------------------------------------------------------------+
-|``eval_statistics.csv``| | File with general performance statistics for the episodes and    |
+|``eval_statistics.csv``| | File with general performance diagnostics for the episodes and    |
 |                       | | disturbances used during the robustness evaluation.              |
 +-----------------------+--------------------------------------------------------------------+
 |``results.csv``        | | Pandas data frame containing all the data that was collected for |

--- a/docs/source/usage/running.rst
+++ b/docs/source/usage/running.rst
@@ -295,18 +295,19 @@ The CLI also contains several (shortcut) flags that can be used to change the be
     :obj:`str`. The tensorboard log frequency. Options are ``low`` (Recommended: logs at every epoch) and
     ``high`` (logs at every SGD update batch). Defaults to ``low`` since this is less resource intensive.
 
-.. option:: --verbose, --logger_kwargs:verbose
+.. option:: --quiet, --logger_kwargs:quiet
 
-    :obj:`bool`. Whether you want to log to the stdout. Defaults to ``False``.
+    :obj:`bool`. Suppress logging of diagnostics to the stdout. Defaults to ``False``.
 
 .. option:: --verbose_fmt, --logger_kwargs:verbose_fmt
 
-    :obj:`bool`. The format in which the statistics are displayed to the terminal. Options are ``table``, which
-    supplies them as a table and ``line``, which prints them in one line. Defaults to ``line``.
+    :obj:`bool`. The format in which the diagnostics are displayed to the terminal when ``quiet`` is ``False``. 
+    Options are ``table``, which supplies them as a table and ``line``, which prints them in one line. 
+    Defaults to ``line``.
 
 .. option:: --verbose_vars, --logger_kwargs:verbose_vars
 
-    :obj:`list`. A list of variables you want to log to the stdout. By default, all variables are logged.
+    :obj:`list`. A list of variables you want to log to the stdout when ``quiet`` is ``False``. By default, all variables are logged.
 
 .. important::
 

--- a/docs/source/utils/loggers.rst
+++ b/docs/source/utils/loggers.rst
@@ -49,7 +49,7 @@ values of ``Test`` to the :class:`~stable_learning_control.utils.log_utils.logx.
 state. Then, when :meth:`~stable_learning_control.utils.log_utils.logx.EpochLogger.log_tabular` is called,
 it computes the average, standard deviation, min, and max of ``Test`` over all of the values in the internal state.
 The internal state is wiped clean after the call to :meth:`~stable_learning_control.utils.log_utils.logx.EpochLogger.log_tabular`
-(to prevent leakage into the statistics at the next epoch). Finally, :meth:`~stable_learning_control.utils.log_utils.logx.EpochLogger.dump_tabular`
+(to prevent leakage into the diagnostics at the next epoch). Finally, :meth:`~stable_learning_control.utils.log_utils.logx.EpochLogger.dump_tabular`
 is called to write the diagnostics to file, Tensorboard and/or stdout.
 
 Next, let's use the :torch:`Pytorch Classifier <tutorials/beginner/blitz/cifar10_tutorial.html>` tutorial to look at an entire training procedure with the logger embedded, to highlight configuration and model
@@ -192,7 +192,7 @@ saving as well as diagnostic logging:
                 accuracy = 100 * correct / len(trainset)
                 running_loss += loss.item()
 
-                # print statistics.
+                # print diagnostics.
                 running_loss += loss.item()
                 if i % 2000 == 1999:  # print every 2000 mini-batches
                     logger.log(

--- a/stable_learning_control/algos/pytorch/lac/lac.py
+++ b/stable_learning_control/algos/pytorch/lac/lac.py
@@ -973,8 +973,8 @@ def lac(
         env.reward_range.shape[0] if isinstance(env.reward_range, gym.spaces.Box) else 1
     )
 
-    logger_kwargs["verbose"] = (
-        logger_kwargs["verbose"] if "verbose" in logger_kwargs.keys() else False
+    logger_kwargs["quiet"] = (
+        logger_kwargs["quiet"] if "quiet" in logger_kwargs.keys() else False
     )
     logger_kwargs["verbose_vars"] = (
         logger_kwargs["verbose_vars"]
@@ -1319,7 +1319,7 @@ def lac(
     if export:
         policy.export(logger.output_dir)
 
-    print("" if logger_kwargs["verbose"] else "\n")
+    print("" if not logger_kwargs["quiet"] else "\n")
     logger.log(
         "Training finished after {}s".format(time.time() - start_time),
         type="info",
@@ -1563,11 +1563,11 @@ if __name__ == "__main__":
         help="the name of the experiment (default: lac)",
     )
     parser.add_argument(
-        "--verbose",
-        "-v",
+        "--quiet",
+        "-q",
         type=bool,
         default=False,
-        help="log diagnostics to stdout (default: False)",
+        help="suppress logging of diagnostics to stdout (default: False)",
     )
     parser.add_argument(
         "--verbose_fmt",
@@ -1636,7 +1636,7 @@ if __name__ == "__main__":
         save_checkpoints=args.save_checkpoints,
         use_tensorboard=args.use_tensorboard,
         tb_log_freq=args.tb_log_freq,
-        verbose=args.verbose,
+        quiet=args.quiet,
         verbose_fmt=args.verbose_fmt,
         verbose_vars=args.verbose_vars,
     )

--- a/stable_learning_control/algos/pytorch/sac/sac.py
+++ b/stable_learning_control/algos/pytorch/sac/sac.py
@@ -918,8 +918,8 @@ def sac(
         env.reward_range.shape[0] if isinstance(env.reward_range, gym.spaces.Box) else 1
     )
 
-    logger_kwargs["verbose"] = (
-        logger_kwargs["verbose"] if "verbose" in logger_kwargs.keys() else False
+    logger_kwargs["quiet"] = (
+        logger_kwargs["quiet"] if "quiet" in logger_kwargs.keys() else False
     )
     logger_kwargs["verbose_vars"] = (
         logger_kwargs["verbose_vars"]
@@ -1230,7 +1230,7 @@ def sac(
     if export:
         policy.export(logger.output_dir)
 
-    print("" if logger_kwargs["verbose"] else "\n")
+    print("" if not logger_kwargs["quiet"] else "\n")
     logger.log(
         "Training finished after {}s".format(time.time() - start_time),
         type="info",
@@ -1468,11 +1468,11 @@ if __name__ == "__main__":
         help="the name of the experiment (default: sac)",
     )
     parser.add_argument(
-        "--verbose",
-        "-v",
+        "--quiet",
+        "-q",
         type=bool,
         default=False,
-        help="log diagnostics to stdout (default: False)",
+        help="suppress logging of diagnostics to stdout (default: False)",
     )
     parser.add_argument(
         "--verbose_fmt",
@@ -1542,7 +1542,7 @@ if __name__ == "__main__":
         save_checkpoints=args.save_checkpoints,
         use_tensorboard=args.use_tensorboard,
         tb_log_freq=args.tb_log_freq,
-        verbose=args.verbose,
+        quiet=args.quiet,
         verbose_fmt=args.verbose_fmt,
         verbose_vars=args.verbose_vars,
     )

--- a/stable_learning_control/algos/tf2/lac/lac.py
+++ b/stable_learning_control/algos/tf2/lac/lac.py
@@ -922,8 +922,8 @@ def lac(
         env.reward_range.shape[0] if isinstance(env.reward_range, gym.spaces.Box) else 1
     )
 
-    logger_kwargs["verbose"] = (
-        logger_kwargs["verbose"] if "verbose" in logger_kwargs.keys() else False
+    logger_kwargs["quiet"] = (
+        logger_kwargs["quiet"] if "quiet" in logger_kwargs.keys() else False
     )
     logger_kwargs["verbose_vars"] = (
         logger_kwargs["verbose_vars"]
@@ -1262,7 +1262,7 @@ def lac(
     if export:
         policy.export(logger.output_dir)
 
-    print("" if logger_kwargs["verbose"] else "\n")
+    print("" if not logger_kwargs["quiet"] else "\n")
     logger.log(
         "Training finished after {}s".format(time.time() - start_time),
         type="info",
@@ -1506,11 +1506,11 @@ if __name__ == "__main__":
         help="the name of the experiment (default: lac)",
     )
     parser.add_argument(
-        "--verbose",
-        "-v",
+        "--quiet",
+        "-q",
         type=bool,
         default=False,
-        help="log diagnostics to stdout (default: False)",
+        help="suppress logging of diagnostics to stdout (default: False)",
     )
     parser.add_argument(
         "--verbose_fmt",
@@ -1579,7 +1579,7 @@ if __name__ == "__main__":
         save_checkpoints=args.save_checkpoints,
         use_tensorboard=args.use_tensorboard,
         tb_log_freq=args.tb_log_freq,
-        verbose=args.verbose,
+        quiet=args.quiet,
         verbose_fmt=args.verbose_fmt,
         verbose_vars=args.verbose_vars,
     )

--- a/stable_learning_control/algos/tf2/sac/sac.py
+++ b/stable_learning_control/algos/tf2/sac/sac.py
@@ -871,8 +871,8 @@ def sac(
         env.reward_range.shape[0] if isinstance(env.reward_range, gym.spaces.Box) else 1
     )
 
-    logger_kwargs["verbose"] = (
-        logger_kwargs["verbose"] if "verbose" in logger_kwargs.keys() else False
+    logger_kwargs["quiet"] = (
+        logger_kwargs["quiet"] if "quiet" in logger_kwargs.keys() else False
     )
     logger_kwargs["verbose_vars"] = (
         logger_kwargs["verbose_vars"]
@@ -1186,7 +1186,7 @@ def sac(
     if export:
         policy.export(logger.output_dir)
 
-    print("" if logger_kwargs["verbose"] else "\n")
+    print("" if not logger_kwargs["quiet"] else "\n")
     logger.log(
         "Training finished after {}s".format(time.time() - start_time),
         type="info",
@@ -1424,11 +1424,11 @@ if __name__ == "__main__":
         help="the name of the experiment (default: sac)",
     )
     parser.add_argument(
-        "--verbose",
-        "-v",
+        "--quiet",
+        "-q",
         type=bool,
         default=False,
-        help="log diagnostics to stdout (default: False)",
+        help="suppress logging of diagnostics to stdout (default: False)",
     )
     parser.add_argument(
         "--verbose_fmt",
@@ -1498,7 +1498,7 @@ if __name__ == "__main__":
         save_checkpoints=args.save_checkpoints,
         use_tensorboard=args.use_tensorboard,
         tb_log_freq=args.tb_log_freq,
-        verbose=args.verbose,
+        quiet=args.quiet,
         verbose_fmt=args.verbose_fmt,
         verbose_vars=args.verbose_vars,
     )

--- a/stable_learning_control/run.py
+++ b/stable_learning_control/run.py
@@ -37,11 +37,11 @@ SUBSTITUTIONS = {
     "act_out_c": "ac_kwargs:output_activation:critic",
     "cpu": "num_cpu",
     "dt": "datestamp",
-    "v": "verbose",
+    "q": "quiet",
     "use_tensorboard": "logger_kwargs:use_tensorboard",
     "save_checkpoints": "logger_kwargs:save_checkpoints",
     "tb_log_freq": "logger_kwargs:tb_log_freq",
-    "verbose": "logger_kwargs:verbose",
+    "quiet": "logger_kwargs:quiet",
     "verbose_fmt": "logger_kwargs:verbose_fmt",
     "verbose_vars": "logger_kwargs:verbose_vars",
 }

--- a/stable_learning_control/user_config.py
+++ b/stable_learning_control/user_config.py
@@ -26,11 +26,11 @@ DEFAULT_SHORTHAND = True
 # Tells the GridSearch how many seconds to pause for before launching experiments.
 WAIT_BEFORE_LAUNCH = 5
 
-# Print config when saved.
-PRINT_CONFIG = True
+# Print experiment config to terminal.
+PRINT_CONFIG = False
 
 # Logger stdout output type.
-# NOTE:The format in which the training statistics are displayed to the terminal.
+# NOTE:The format in which the training diagnostics are displayed to the terminal.
 # Options are "table"  which supplies them as a table and "line" which prints them in
 # one line.
 DEFAULT_STD_OUT_TYPE = "line"

--- a/stable_learning_control/utils/log_utils/helpers.py
+++ b/stable_learning_control/utils/log_utils/helpers.py
@@ -114,7 +114,7 @@ def setup_logger_kwargs(
     save_checkpoints=False,
     use_tensorboard=False,
     tb_log_freq="low",
-    verbose=False,
+    quiet=False,
     verbose_fmt=DEFAULT_STD_OUT_TYPE,
     verbose_vars=[],
     data_dir=None,
@@ -153,9 +153,9 @@ def setup_logger_kwargs(
         tb_log_freq (str, optional): The tensorboard log frequency. Options are ``low``
             (Recommended: logs at every epoch) and ``high`` (logs at every SGD update "
             batch). Defaults to ``low`` since this is less resource intensive.
-        verbose (bool, optional): Whether you want to log to the stdout. Defaults
-            to ``False``.
-        verbose_fmt (str, optional): The format in which the statistics are
+        quiet (bool, optional): Whether you want to suppress logging of the diagnostics
+            to the stdout. Defaults to ``False``.
+        verbose_fmt (str, optional): The format in which the diagnostics are
             displayed to the terminal. Options are ``table`` which supplies them as a
             table and ``line`` which prints them in one line. Defaults to ``line``.
         verbose_vars (list, optional): A list of variables you want to log to the
@@ -193,7 +193,7 @@ def setup_logger_kwargs(
         save_checkpoints=save_checkpoints,
         use_tensorboard=use_tensorboard,
         tb_log_freq=tb_log_freq,
-        verbose=verbose,
+        quiet=quiet,
         verbose_fmt=verbose_fmt,
         verbose_vars=verbose_vars,
     )

--- a/tests/algos/gpu/test_algos_gpu.py
+++ b/tests/algos/gpu/test_algos_gpu.py
@@ -39,6 +39,7 @@ class TestTorchAlgosGPU:
             epochs=1,
             update_after=400,
             steps_per_epoch=800,
+            logger_kwargs=dict(quiet=True),
             device=device,
         )
 

--- a/tests/algos/test_algos.py
+++ b/tests/algos/test_algos.py
@@ -38,6 +38,7 @@ class TestTorchAlgos:
             epochs=1,
             update_after=400,
             steps_per_epoch=800,
+            logger_kwargs=dict(quiet=True),
             device="cpu",
         )
 

--- a/tests/algos/tf2/gpu/test_tf2_algos_gpu.py
+++ b/tests/algos/tf2/gpu/test_tf2_algos_gpu.py
@@ -50,6 +50,7 @@ class TestTF2AlgosGPU:
             epochs=1,
             update_after=400,
             steps_per_epoch=800,
+            logger_kwargs=dict(quiet=True),
             device=device,
         )
 

--- a/tests/algos/tf2/test_tf2_algos.py
+++ b/tests/algos/tf2/test_tf2_algos.py
@@ -44,6 +44,7 @@ class TestTF2Algos:
             epochs=1,
             update_after=400,
             steps_per_epoch=800,
+            logger_kwargs=dict(quiet=True),
             device="cpu",
         )
 


### PR DESCRIPTION
This pull request replaces the `verbose` logger_kwarg with `quiet`, causing verbose logging to be enabled by default. It provides an option to disable configuration logging.
