### PR TITLE
fix: fix 'test_policy' rendering

### DIFF
--- a/stable_learning_control/__init__.py
+++ b/stable_learning_control/__init__.py
@@ -5,8 +5,8 @@ from stable_learning_control.algos.pytorch.sac.sac import sac as sac_pytorch
 from stable_learning_control.utils.import_utils import tf_installed
 
 # Make module version available.
-from .version import __version__  # noqa: F401
-from .version import __version_tuple__  # noqa: F401
+from .version import __version__
+from .version import __version_tuple__
 
 if tf_installed():
     from stable_learning_control.algos.tf2.lac.lac import lac as lac_tf2

--- a/stable_learning_control/algos/pytorch/lac/lac.py
+++ b/stable_learning_control/algos/pytorch/lac/lac.py
@@ -1008,7 +1008,7 @@ def lac(
             logger.log(
                 (
                     f"You defined your 'max_ep_len' to be {max_ep_len} "
-                    "while the environment 'max_epsisode_steps' is "
+                    "while the environment 'max_episode_steps' is "
                     f"{env.env._max_episode_steps}. As a result the environment "
                     f"'max_episode_steps' has been increased to {max_ep_len}"
                 ),

--- a/stable_learning_control/algos/pytorch/sac/sac.py
+++ b/stable_learning_control/algos/pytorch/sac/sac.py
@@ -953,7 +953,7 @@ def sac(
             logger.log(
                 (
                     f"You defined your 'max_ep_len' to be {max_ep_len} "
-                    "while the environment 'max_epsisode_steps' is "
+                    "while the environment 'max_episode_steps' is "
                     f"{env.env._max_episode_steps}. As a result the environment "
                     f"'max_episode_steps' has been increased to {max_ep_len}"
                 ),

--- a/stable_learning_control/algos/tf2/lac/lac.py
+++ b/stable_learning_control/algos/tf2/lac/lac.py
@@ -958,7 +958,7 @@ def lac(
             logger.log(
                 (
                     f"You defined your 'max_ep_len' to be {max_ep_len} "
-                    "while the environment 'max_epsisode_steps' is "
+                    "while the environment 'max_episode_steps' is "
                     f"{env.env._max_episode_steps}. As a result the environment "
                     f"'max_episode_steps' has been increased to {max_ep_len}"
                 ),

--- a/stable_learning_control/algos/tf2/sac/sac.py
+++ b/stable_learning_control/algos/tf2/sac/sac.py
@@ -907,7 +907,7 @@ def sac(
             logger.log(
                 (
                     f"You defined your 'max_ep_len' to be {max_ep_len} "
-                    "while the environment 'max_epsisode_steps' is "
+                    "while the environment 'max_episode_steps' is "
                     f"{env.env._max_episode_steps}. As a result the environment "
                     f"'max_episode_steps' has been increased to {max_ep_len}"
                 ),


### PR DESCRIPTION
This commit ensures that the 'test_policy' utility is compatible with
the rendering behavoir in Gymnasium > v21 (see https://younis.dev/blog/render-api/).
