### PR TITLE
refactor: add 'SwimmerCost' exp configs

### DIFF
--- a/experiments/han_et_al_2020/lac_swimmer_cost_experiment.yml
+++ b/experiments/han_et_al_2020/lac_swimmer_cost_experiment.yml
@@ -1,0 +1,37 @@
+alg_name: lac
+exp_name: lac_swimmer_cost_exp
+env_name: "stable_gym:SwimmerCost-v1"
+ac_kwargs:
+  hidden_sizes:
+    actor: [64, 64]
+    critic: [64, 64, 16] # NOTE: Haarnoja et al. 2018 uses [256, 256].
+  activation:
+    actor: "nn.ReLU" 
+    critic: "nn.ReLU"
+  output_activation:
+    actor: "nn.ReLU"
+opt_type: "minimize"
+max_ep_len: 250
+epochs: 490
+steps_per_epoch: 2048
+start_steps: 0
+update_every: 100
+update_after: 1000
+steps_per_update: 80 # NOTE: Haarnoja et al. 2018 uses 1.0.
+num_test_episodes: 10
+alpha: 2.0
+alpha3: 0.1 # NOTE: Han et al. 2020 article states 1.0 (see #284).
+labda: 0.99 # NOTE: Han et al. 2020 uses 1.0.
+gamma: 0.995
+polyak: 0.995
+adaptive_temperature: True
+lr_a: "1e-4"
+lr_c: "3e-4"
+lr_a_final: "1e-10" # NOTE: Not present in Han et al. 2020.
+lr_c_final: "1e-10" # NOTE: Not present in Han et al. 2020.
+lr_decay_type: "linear"
+lr_decay_ref: "epoch" # NOTE: Han et al. 2020 decays per step.
+batch_size: 256
+replay_size: "int(1e6)"
+seed: 0 48104 567 3658 23 17728 90478 753044 443 102132 
+save_freq: 10

--- a/experiments/han_et_al_2020/sac_swimmer_cost_experiment.yml
+++ b/experiments/han_et_al_2020/sac_swimmer_cost_experiment.yml
@@ -1,0 +1,35 @@
+alg_name: sac
+exp_name: sac_swimmer_cost_exp
+env_name: "stable_gym:SwimmerCost-v1"
+ac_kwargs:
+  hidden_sizes:
+    actor: [64, 64]
+    critic: [64, 64, 16] # NOTE: Haarnoja et al. 2018 uses [256, 256].
+  activation:
+    actor: "nn.ReLU" 
+    critic: "nn.ReLU"
+  output_activation:
+    actor: "nn.ReLU"
+opt_type: "minimize"
+max_ep_len: 250
+epochs: 490
+steps_per_epoch: 2048
+start_steps: 0
+update_every: 100
+update_after: 1000
+steps_per_update: 50 # NOTE: Haarnoja et al. 2018 uses 1.0.
+num_test_episodes: 10
+alpha: 1.0
+gamma: 0.995
+polyak: 0.995
+adaptive_temperature: True
+lr_a: "1e-4"
+lr_c: "3e-4"
+lr_a_final: "1e-10" # NOTE: Not present in Han et al. 2020.
+lr_c_final: "1e-10" # NOTE: Not present in Han et al. 2020.
+lr_decay_type: "linear"
+lr_decay_ref: "epoch" # NOTE: Han et al. 2020 decays per step.
+batch_size: 256
+replay_size: "int(1e6)"
+seed: 0 48104 567 3658 23 17728 90478 753044 443 102132 
+save_freq: 10

--- a/experiments/staa_et_al_2023/lac_swimmer_cost_experiment.yml
+++ b/experiments/staa_et_al_2023/lac_swimmer_cost_experiment.yml
@@ -1,0 +1,37 @@
+alg_name: lac
+exp_name: lac_swimmer_cost_exp
+env_name: "stable_gym:SwimmerCost-v1"
+ac_kwargs:
+  hidden_sizes:
+    actor: [256, 256] # NOTE: Han et al. 2020 code uses [64, 64].
+    critic: [64, 64, 16] # NOTE: Haarnoja et al. 2018 uses [256, 256].
+  activation:
+    actor: "nn.ReLU" 
+    critic: "nn.ReLU"
+  output_activation:
+    actor: "nn.ReLU"
+opt_type: "minimize"
+max_ep_len: 250
+epochs: 490
+steps_per_epoch: 2048
+start_steps: 0
+update_every: 100
+update_after: 1000
+steps_per_update: 80 # NOTE: Haarnoja et al. 2018 uses 1.0.
+num_test_episodes: 10
+alpha: 2.0
+alpha3: 0.1 # NOTE: Han et al. 2020 article states 1.0 (see #284).
+labda: 0.99 # NOTE: Han et al. 2020 uses 1.0.
+gamma: 0.995
+polyak: 0.995
+adaptive_temperature: True
+lr_a: "1e-4"
+lr_c: "3e-4"
+lr_a_final: "1e-10" # NOTE: Not present in Han et al. 2020.
+lr_c_final: "1e-10" # NOTE: Not present in Han et al. 2020.
+lr_decay_type: "linear"
+lr_decay_ref: "epoch" # NOTE: Han et al. 2020 decays per step.
+batch_size: 256
+replay_size: "int(1e6)"
+seed: 0 48104 567 3658 23 17728 90478 753044 443 102132 
+save_freq: 10

--- a/experiments/staa_et_al_2023/sac_swimmer_cost_experiment.yml
+++ b/experiments/staa_et_al_2023/sac_swimmer_cost_experiment.yml
@@ -1,0 +1,35 @@
+alg_name: sac
+exp_name: sac_swimmer_cost_exp
+env_name: "stable_gym:SwimmerCost-v1"
+ac_kwargs:
+  hidden_sizes:
+    actor: [256, 256] # NOTE: Han et al. 2020 code uses [64, 64].
+    critic: [64, 64, 16] # NOTE: Haarnoja et al. 2018 uses [256, 256].
+  activation:
+    actor: "nn.ReLU" 
+    critic: "nn.ReLU"
+  output_activation:
+    actor: "nn.ReLU"
+opt_type: "minimize"
+max_ep_len: 250
+epochs: 490
+steps_per_epoch: 2048
+start_steps: 0
+update_every: 100
+update_after: 1000
+steps_per_update: 80 # NOTE: Haarnoja et al. 2018 uses 1.0.
+num_test_episodes: 10
+alpha: 2.0 # NOTE: Han et al. 2020 uses 1.0 in the code.
+gamma: 0.995
+polyak: 0.995
+adaptive_temperature: True
+lr_a: "1e-4"
+lr_c: "3e-4"
+lr_a_final: "1e-10" # NOTE: Not present in Han et al. 2020.
+lr_c_final: "1e-10" # NOTE: Not present in Han et al. 2020.
+lr_decay_type: "linear"
+lr_decay_ref: "epoch" # NOTE: Han et al. 2020 decays per step.
+batch_size: 256
+replay_size: "int(1e6)"
+seed: 0 48104 567 3658 23 17728 90478 753044 443 102132 
+save_freq: 10


### PR DESCRIPTION
This pull request adds experimental configs for the SwimmerCost experiments of [Han et al. 2020](https://arxiv.org/abs/2004.14288).