### PR TITLE
feat(latc): add LATC algorithm

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,6 +72,7 @@ latex_packages = r"""
 \usepackage{amsmath}
 \usepackage{cancel}
 \usepackage{physics}
+\usepackage{bm}
 """
 latex_macros = r"""
 \newcommand{\E}{{\mathrm E}}

--- a/docs/source/dev/doc_dev.rst
+++ b/docs/source/dev/doc_dev.rst
@@ -34,12 +34,10 @@ the ``docs/build/html`` directory. If the documentation is successfully created,
 ``make linkcheck`` command to check for broken links.
 
 .. attention::
-
     Ensure you are in the Conda environment where you installed the :slc:`stable_learning_control <>`
     package with its dependencies.
 
 .. note::
-
     Sometimes the ``make linkcheck`` command doesn't show the results on the stdout. You can also find the results
     in the ``docs/build/linkcheck`` folder. 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,6 @@ ready-to-use compatible environments can be found in the  :stable-gym:`stable-gy
 :ros-gazebo-gym:`Ros Gazebo Gym <>` packages.
 
 .. note::
-
    This framework was built upon the `SpinningUp`_ educational resource. By doing this, we 
    hope to make it easier for new researchers to start with our Algorithms. If you are new
    to RL, check out the SpinningUp documentation and play with it before diving into our

--- a/docs/source/usage/algorithms.rst
+++ b/docs/source/usage/algorithms.rst
@@ -17,7 +17,6 @@ Stable Agents
 -------------
 
 .. important::
-
    As explained in the :ref:`installation section <gym_envs_install>` of the documentation,
    although the ``opt_type`` algorithm variable can be used to train on standard
    :gymnasium:`gymnasium <>` environments, the stable RL agents require a positive definite
@@ -31,6 +30,7 @@ The SLC package currently contains the following theoretically stable RL algorit
    :maxdepth: 1
 
    algorithms/lac
+   algorithms/latc
 
 Unstable Agents
 ---------------

--- a/docs/source/usage/algorithms/lac.rst
+++ b/docs/source/usage/algorithms/lac.rst
@@ -1,13 +1,12 @@
 .. _lac:
 
-=====================
-Lyapunov Actor-Critic
-=====================
+===========================
+Lyapunov Actor-Critic (LAC)
+===========================
 
 .. contents:: Table of Contents
 
 .. seealso::
-
     This document assumes you are familiar with the `Soft Actor-Critic (SAC)`_ algorithm.
     It is not meant to be a comprehensive guide but mainly depicts the difference between
     the :ref:`SAC <sac>` and `Lyapunov Actor-Critic (LAC)`_ algorithms. For more information,
@@ -21,7 +20,6 @@ Lyapunov Actor-Critic
 
 
 .. important::
-
     The LAC algorithm only guarantees stability in **mean cost** when trained on environments 
     with a positive definite cost function (i.e. environments in which the cost is minimized).
     The ``opt_type`` argument can be set to ``maximize`` when training in environments where
@@ -120,9 +118,14 @@ Where :math:`L_{target}` is the approximation target received from the `infinite
 and :math:`\mathcal{D}` the set of collected transition pairs.
 
 .. note::
-
     As explained by `Han et al., 2020`_ the sum of cost over a finite time horizon can also be used as the
     approximation target. This version still needs to be implemented in the SLC framework.
+
+.. seealso:: 
+    The SLC package also contains a LAC implementation using a double Q-Critic (i.e., :ref:`Lyapunov Twin Critic <latc>`).
+    For more information about this version, see the :ref:`LAC Twin Critic <latc>` documentation. This version can be used
+    by specifying the ``latc`` algorithm in the CLI, by supplying the :meth:`~stable_learning_control.algos.pytorch.lac.lac.lac` function with the ``actor_critic=LyapunovActorTwinCritic``
+    argument or by directly calling the :meth:`~stable_learning_control.algos.pytorch.lac.latc.latc` function.
 
 .. _`mean-squared Bellman error (MSBE) minimisation`: https://spinningup.openai.com/en/latest/algorithms/ddpg.html?highlight=msbe#the-q-learning-side-of-ddpg
 .. _`infinite-horizon discounted return value function`: https://spinningup.openai.com/en/latest/spinningup/rl_intro.html#value-functions
@@ -197,7 +200,6 @@ For more information on the LAC algorithm, please check out the original paper o
 
 .. _`Han et al., 2020`: https://arxiv.org/abs/2004.14288
 
-
 Pseudocode
 ----------
 
@@ -221,9 +223,6 @@ Pseudocode
         \UNTIL{eq. 11 of Han et al., 2020 is satisfied}
     \end{algorithmic}
     \end{algorithm}
-
-.. _`11 of Han et al., 2020`: https://arxiv.org/pdf/2004.14288.pdf
-.. _`eq. (7) and (14) from Han et al., 2020`: https://arxiv.org/pdf/2004.14288.pdf
 
 Implementation
 ==============
@@ -251,7 +250,6 @@ Algorithm: TensorFlow Version
 -----------------------------
 
 .. attention::
-
     The TensorFlow version is still experimental. It is not guaranteed to work, and it is not
     guaranteed to be up-to-date with the PyTorch version.
 
@@ -260,7 +258,7 @@ Algorithm: TensorFlow Version
 Saved Model Contents: TensorFlow Version
 ----------------------------------------
 
-The TensorFlow version of the SAC algorithm is implemented by subclassing the :class:`tf.nn.Model` class. As a result, both the
+The TensorFlow version of the LAC algorithm is implemented by subclassing the :class:`tf.nn.Model` class. As a result, both the
 full model and the current model weights are saved. The complete model can be found in the ``saved_model.pb`` file, while the current
 weights checkpoints are found in the ``tf_safe/weights_checkpoint*`` file. For an example of using these two methods, see :ref:`saving_and_loading`
 or the :tensorflow:`TensorFlow documentation <tutorials/keras/save_and_load>`.

--- a/docs/source/usage/algorithms/latc.rst
+++ b/docs/source/usage/algorithms/latc.rst
@@ -1,0 +1,141 @@
+.. _latc:
+
+=================================
+Lyapunov Actor-Twin Critic (LATC) 
+=================================
+
+.. contents:: Table of Contents
+
+.. seealso::
+    This document assumes you are familiar with the :ref:`Lyapunov Actor-Critic (LAC) <lac>` algorithm.
+    It is not a comprehensive guide but mainly depicts the difference between the
+    :ref:`Lyapunov Actor-Twin Critic <latc>` and :ref:`Lyapunov Actor-Critic (LAC) <lac>` algorithms. It
+    is therefore meant to complement the :ref:`LAC <lac>` algorithm documentation.
+
+.. important::
+    Like the LAC algorithm, this LATC algorithm only guarantees stability in **mean cost** when trained on
+    environments with a positive definite cost function (i.e. environments in which the cost is minimised).
+    The ``opt_type`` argument can be set to ``maximise `` when training in environments where the reward is
+    maximised. However, because the `Lyapunov's stability conditions`_ are not satisfied, the LAC algorithm
+    no longer guarantees stability in **mean** cost.
+
+.. _`Lyapunov's stability conditions`: https://www.cds.caltech.edu/~murray/courses/cds101/fa02/caltech/mls93-lyap.pdf
+
+Background
+==========
+
+The Laypunov Actor-Twin Critic (LATC) algorithm is a successor to the :ref:`LAC <lac>` algorithm. In contrast
+to its predecessor, the LATC algorithm employs a dual-critic approach, aligning it more closely with the
+:ref:`SAC <sac>` algorithm upon which LAC was built initially. In the SAC framework, these dual critics
+served to counteract overestimation bias by selecting the minimum value from both critics for the actor updates. 
+In our case, we employ the maximum to minimise the cost, thus addressing potential underestimation bias in
+Lyapunov values. For a deeper exploration of this concept, refer to the research paper by `Haarnoja et. al 2019`_.
+For more information on the inner workings of the LAC algorithm, refer to the :ref:`LAC <lac>` algorithm
+documentation. Below only the differences between the LAC and LATC algorithms are discussed.
+
+.. _`Haarnoja et. al 2019`: https://arxiv.org/abs/1801.01290
+
+Differences with the LAC algorithm
+------------------------------------
+
+Like its direct predecessor, the LATC algorithm also uses **entropy regularisation** to increase exploration and a
+Gaussian actor and value-critic to develop the best action. The main difference lies in the fact that the
+:class:`~stable_learning_control.algos.pytorch.policies.lyapunov_actor_twin_critic.LyapunovActorTwinCritic`
+contains two critic instead of one. These critics are identical to the critic used in the :ref:`LAC <lac>`
+algorithm but trained separately. Following their maximum is used to update the actor. Because of this the policy issues
+optimised according to
+
+.. math::
+    :label: latc_policy_update
+
+    \min_{\theta} \underE{s \sim \mathcal{D} \\ \xi \sim \mathcal{N}}{\lambda(\bm{L_{c_{max}}(s^{'}, f_{\theta}(\epsilon, s^{'})})-L_{c}(s, a) + \alpha_{3}c) + \mathcal{\alpha}\log \pi_{\theta}(f_{\theta}(\epsilon, s)|s) + \mathcal{H}_{t}}
+
+Where :math:`L_{c_{max}}` now represents the maximum of the two critics. The rest of the algorithm remains the same.
+
+.. important:: 
+    Because the LATC and LAC algorithms are so similar, the :meth:`~stable_learning_control.algos.pytorch.latc.latc` is
+    implemented as a wrapper around the :meth:`~stable_learning_control.algos.pytorch.lac.lac` function. This wrapper
+    only changes the actor-critic architecture to :class:`~stable_learning_control.algos.pytorch.policies.lyapunov_actor_twin_critic.LyapunovActorTwinCritic`.
+    To prevent code duplication, the :class:`stable_learning_control.algos.pytorch.policies.lyapunov_actor_critic.LyapunovActorCritic` class
+    was modified to use the maximum of the two critics when the :class:`~stable_learning_control.algos.pytorch.policies.lyapunov_actor_twin_critic.LyapunovActorTwinCritic`
+    class is set as the actor-critic architecture.
+
+Quick Fact
+----------
+
+* LATC is an off-policy algorithm.
+* It is guaranteed to be stable in mean cost.
+* The version of LATC implemented here can only be used for environments with continuous action spaces.
+* An alternate version of LATC, which slightly changes the policy update rule, can be implemented to handle discrete action spaces.
+* The SLC implementation of LATC does not support parallelisation.
+
+
+Further Reading
+---------------
+
+For more information on the LATC algorithm, please check out the :ref:`LAC <lac>` documentation and the original paper of `Han et al., 2020`_.
+
+.. _`Han et al., 2020`: https://arxiv.org/abs/2004.14288
+
+Pseudocode
+----------
+
+.. math::
+    :nowrap:
+
+    \begin{algorithm}[H]
+        \caption{Lyapunov-based Actor-Twin Critic (LATC)}
+        \label{alg1}
+    \begin{algorithmic}[1]
+        \REQUIRE Maximum episode length $N$ and maximum update steps $M$
+        \REPEAT
+            \STATE Samples $s_{0}$ according to $\rho$
+            \FOR{$t=1$ to $N$}
+                \STATE Sample $a$ from $\pi(a|s)$ and step forward
+                \STATE Observe $s'$, $c$ and store ($s$, $a$, $c$, $s'$) in $\mathcal{D}$
+            \ENDFOR
+            \FOR{$i=1$ to $M$}
+                \STATE Sample mini-batches of transitions from $D$ and update $L_{c}$, $L2_{c}$, $\pi$, Lagrance multipliers with eq. (7) and (14) of Han et al., 2020 and the new actor update rule described above
+            \ENDFOR
+        \UNTIL{eq. 11 of Han et al., 2020 is satisfied}
+    \end{algorithmic}
+    \end{algorithm}
+
+Implementation
+==============
+
+.. admonition:: You Should Know
+
+    In what follows, we give documentation for the PyTorch and TensorFlow implementations of LATC in SLC.
+    They have nearly identical function calls and docstrings, except for details relating to model construction.
+    However, we include both full docstrings for completeness.
+
+Algorithm: PyTorch Version
+--------------------------
+
+.. autofunction:: stable_learning_control.algos.pytorch.latc.latc
+
+Saved Model Contents: PyTorch Version
+-------------------------------------
+
+The PyTorch version of the LATC algorithm is implemented by subclassing the :class:`torch.nn.Module` class. Because of this and because
+the LATC algorithm is implemented as a wrapper around the LAC algorithm; the model weights are saved using the ``model_state`` dictionary ( :attr:`~stable_learning_control.algos.pytorch.lac.LAC.state_dict`). 
+These saved weights can be found in the ``torch_save/model_state.pt`` file. For an example of how to load a model using
+this file, see :ref:`saving_and_loading` or the :torch:`PyTorch documentation <tutorials/beginner/saving_loading_models.html>`.
+
+Algorithm: TensorFlow Version
+-----------------------------
+
+.. attention::
+    The TensorFlow version is still experimental. It is not guaranteed to work, and it is not
+    guaranteed to be up-to-date with the PyTorch version.
+
+.. autofunction:: stable_learning_control.algos.tf2.latc.latc
+
+Saved Model Contents: TensorFlow Version
+----------------------------------------
+
+The TensorFlow version of the LATC algorithm is implemented by subclassing the :class:`tf.nn.Model` class. As a result, both the
+full model and the current model weights are saved. The complete model can be found in the ``saved_model.pb`` file, while the current
+weights checkpoints are found in the ``tf_safe/weights_checkpoint*`` file. For an example of using these two methods, see :ref:`saving_and_loading`
+or the :tensorflow:`TensorFlow documentation <tutorials/keras/save_and_load>`.

--- a/docs/source/usage/algorithms/sac.rst
+++ b/docs/source/usage/algorithms/sac.rst
@@ -7,7 +7,6 @@ Soft Actor-Critic
 .. contents:: Table of Contents
 
 .. important::
-
     The SAC algorithm has no stability guarantees. Please use the :ref:`LAC <lac>` algorithm if
     you require stability guarantees.
 
@@ -88,7 +87,6 @@ Algorithm: TensorFlow Version
 ---------------------------------
 
 .. attention::
-
     The TensorFlow version is still experimental. It is not guaranteed to work, and it is not
     guaranteed to be up-to-date with the PyTorch version.
 

--- a/docs/source/usage/eval_robustness.rst
+++ b/docs/source/usage/eval_robustness.rst
@@ -31,7 +31,6 @@ The most important input arguments are:
     :class:`~stable_learning_control.disturbers.ObservationRandomNoiseDisturber` disturber).
 
 .. note::
-
     For more information about all the input arguments available for the ``eval_robustness`` tool you can use the ``--help`` flag or check the :ref:`robustness evaluation utility <eval_robustness>`
     documentation or :ref:`the API reference <autoapi>`.
 
@@ -91,7 +90,6 @@ The robustness evaluation tool can save several files to disk that contain infor
 These files will be saved inside the ``eval`` directory inside the output directory.
 
 .. tip:: 
-    
     You can also log these results to Weights & Biases by adding the and ``--use_wandb`` flag to the
     CLI command (see :ref:`eval_robustness` for more information).
 

--- a/docs/source/usage/hyperparameter_tuning.rst
+++ b/docs/source/usage/hyperparameter_tuning.rst
@@ -25,7 +25,6 @@ environment with various values for actor and critic learning rates using the :r
 .. _`CartPoleCost-v0`: https://rickstaa.dev/stable-gym/envs/classic_control/cartpole_cost.html
 
 .. tip:: 
-    
     You can enable logging of TensorBoard and Weights & Biases by adding the ``--use_tensorboard`` and ``--use_wandb`` flags to the
     above command. These tools will allow you to track the performance of your experiments and compare the results of
     different hyperparameter combinations. For more information on how to use these logging utilities, see :ref:`loggers`.

--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -28,7 +28,6 @@ For mac this command can be used:
     brew install openmpi
 
 .. note::
-
     The `Microsoft MPI`_ package can be used for Windows. 
 
 .. attention::
@@ -95,7 +94,6 @@ this environment. The SLC has two versions you can install:
       of the RL algorithms.
 
 .. note::
-
     We choose PyTorch as the default backend as it is easier to work with than TensorFlow. However, at the
     time of writing, it is slightly slower than the TensorFlow backend. This is caused because the agents
     used in the SLC package use components not yet supported by :torch:`TorchScript <docs/stable/jit.html>`
@@ -116,8 +114,6 @@ you can install the SLC package using the following bash command:
 This command will install the SLC package with the :torch:`Pytorch <>` backend in your Conda environment.
 
 .. important::
-
-    
     If you are using Conda, you may come across issues while installing or utilizing the SLC package,
     such as installation errors or script freezing. To effectively resolve these problems, it is
     recommended to install the mpi4py_ package from within Conda instead of using pip. This can
@@ -133,7 +129,6 @@ Install the TensorFlow version
 ------------------------------
 
 .. attention::
-
     As stated above, the Pytorch version was used during our experiments. As a result, the
     TensorFlow version is less well-tested than the Pytorch version and has limited support.
     It should therefore be considered experimental, as no guarantees can be given about the
@@ -147,7 +142,6 @@ package with the the following command:
     pip install -e .[tf2]
 
 .. warning::
-
     If you want to use the GPU version of TensorFlow, you must ensure you performed all
     the steps described in the `TensorFlow installation guide`_. It is also essential to
     know that depending on the version of TensorFlow and PyTorch you use, you might have

--- a/docs/source/usage/plotting.rst
+++ b/docs/source/usage/plotting.rst
@@ -13,7 +13,6 @@ SLC ships with a simple plotting utility that can be used to plot diagnostics fr
         [--select [SELECT [SELECT ...]]] [--exclude [EXCLUDE [EXCLUDE ...]]] [--est EST]
 
 .. seealso::
-
     For more information on this utility, see the :ref:`plot utility <plot>` documentation or code :ref:`the API reference <autoapi>`.
 
 .. figure:: ../images/plots/lac/example_lac_performance_plot.svg
@@ -22,6 +21,5 @@ SLC ships with a simple plotting utility that can be used to plot diagnostics fr
     Example plot that displays the performance of the LAC algorithm.
 
 ..  tip::
-
     The SLC package also supports TensorBoard and Weights & Biases logging. See :ref:`loggers` for more information. This allows you
     to inspect your experiments' results during training and compare the performance of different algorithms more interactively.

--- a/docs/source/usage/running.rst
+++ b/docs/source/usage/running.rst
@@ -106,7 +106,6 @@ the runner will look in ``stable_learning_control/user_config.py`` for which ver
 default to that algorithm.
 
 .. attention::
-
     The TensorFlow version is still experimental. It is not guaranteed to work, and it is not
     guaranteed to be up-to-date with the PyTorch version.
 
@@ -334,7 +333,6 @@ The CLI also contains several (shortcut) flags that can be used to change the be
     :obj:`list`. A list of variables you want to log to the stdout when ``quiet`` is ``False``. The default :obj:`None` means that all variables are logged.
 
 .. important::
-
     The verbose_vars list should be supplied as a list that can be evaluated in Python (e.g. 
     ``--verbose_vars ["Lr_a", "Lr_c"]``).
 
@@ -360,7 +358,6 @@ by `Haarnoja et al., 2019`_.
 
 
 .. important::
-
     Please note that if you want to run multiple hyperparameter variants, for example, multiple seeds or
     learning rates, you have to use comma/space-separated strings in your configuration file:
 

--- a/docs/source/usage/saving_and_loading.rst
+++ b/docs/source/usage/saving_and_loading.rst
@@ -154,7 +154,6 @@ is successfully saved alongside the agent, you can watch the trained agent act i
     python -m stable_learning_control.run test_policy [path/to/output_directory]
 
 .. seealso::
-
     For more information on using this utility, see the :ref:`test_policy` documentation or the code :ref:`the API reference <autoapi>`.
 
 .. _manual_policy_testing:
@@ -318,7 +317,6 @@ Deploy PyTorch Algorithms
 -------------------------
 
 .. attention::
-
     PyTorch provides multiple ways to deploy trained models to hardware (see the :torch:`PyTorch serving documentation <blog/model-serving-in-pyorch>`). 
     Unfortunately, at the time of writing, these methods currently do not support the agents used in the SLC package. For more information, see
     `this issue`_.

--- a/docs/source/utils/testers.rst
+++ b/docs/source/utils/testers.rst
@@ -45,7 +45,6 @@ is successfully saved alongside the agent, it's a cinch to watch the trained age
     different training points (eg watch at iteration 50, 100, 150, etc.). The default value of this flag means "use the latest snapshot."
 
     .. important::
-
         This option only works if snapshots were saved while training the agent (i.e. the ``--save_checkpoints`` flag was set). For more information on
         storing these snapshots see :ref:`alg_flags`.
 
@@ -57,7 +56,6 @@ is successfully saved alongside the agent, it's a cinch to watch the trained age
     for any other algorithms.
 
 .. seealso::
-
     If you receive an "Environment not found" error, see :ref:`manual_policy_testing`.
 
 .. _eval_robustness:
@@ -108,7 +106,6 @@ is successfully saved alongside the agent, the robustness can be evaluated using
     different points in training (e.g. at iteration 50, 100, 150, etc.). The default value of ``-1`` means "use the latest snapshot."
 
     .. important::
-
         This option only works if snapshots were saved while training the agent (i.e. the ``--save_checkpoints`` flag was set). For more information on
         storing these snapshots, see :ref:`alg_flags`.
 
@@ -204,5 +201,4 @@ is successfully saved alongside the agent, the robustness can be evaluated using
     directory and disturber.
 
 .. seealso::
-
     If you receive an "Environment not found" error, see :ref:`manual_policy_testing`.

--- a/examples/pytorch/lac_ray_hyper_parameter_tuning.py
+++ b/examples/pytorch/lac_ray_hyper_parameter_tuning.py
@@ -10,7 +10,6 @@ hyperparameters of a running trial. It was based on the `tutorial`_ provided by 
 Ray team.
 
 .. note::
-
     This example also contains a :cont:`USE_WANDB` flag that allows you to log the
     results of the hyperparameter search to `Weights & Biases`_ (WandB). For more
     information on how to use WandB, see the `Weights & Biases documentation`_.

--- a/examples/pytorch/sac_ray_hyper_parameter_tuning.py
+++ b/examples/pytorch/sac_ray_hyper_parameter_tuning.py
@@ -10,7 +10,6 @@ hyperparameters of a running trial. It was based on the `tutorial`_ provided by 
 Ray team.
 
 .. note::
-
     This example also contains a :cont:`USE_WANDB` flag that allows you to log the
     results of the hyperparameter search to `Weights & Biases`_ (WandB). For more
     information on how to use WandB, see the `Weights & Biases documentation`_.

--- a/examples/tf2/lac_ray_hyper_parameter_tuning.py
+++ b/examples/tf2/lac_ray_hyper_parameter_tuning.py
@@ -10,7 +10,6 @@ hyperparameters of a running trial. It was based on the `tutorial`_ provided by 
 Ray team.
 
 .. note::
-
     This example also contains a :cont:`USE_WANDB` flag that allows you to log the
     results of the hyperparameter search to `Weights & Biases`_ (WandB). For more
     information on how to use WandB, see the `Weights & Biases documentation`_.

--- a/examples/tf2/sac_ray_hyper_parameter_tuning.py
+++ b/examples/tf2/sac_ray_hyper_parameter_tuning.py
@@ -10,7 +10,6 @@ hyperparameters of a running trial. It was based on the `tutorial`_ provided by 
 Ray team.
 
 .. note::
-
     This example also contains a :cont:`USE_WANDB` flag that allows you to log the
     results of the hyperparameter search to `Weights & Biases`_ (WandB). For more
     information on how to use WandB, see the `Weights & Biases documentation`_.

--- a/stable_learning_control/__init__.py
+++ b/stable_learning_control/__init__.py
@@ -1,6 +1,7 @@
 """Module that Initialises the stable_learning_control package."""
 # Put algorithms in main namespace.
 from stable_learning_control.algos.pytorch.lac.lac import lac as lac_pytorch
+from stable_learning_control.algos.pytorch.latc.latc import latc as latc_pytorch
 from stable_learning_control.algos.pytorch.sac.sac import sac as sac_pytorch
 from stable_learning_control.utils.import_utils import tf_installed
 
@@ -10,4 +11,5 @@ from .version import __version_tuple__
 
 if tf_installed():
     from stable_learning_control.algos.tf2.lac.lac import lac as lac_tf2
+    from stable_learning_control.algos.tf2.latc.latc import latc as latc_tf2
     from stable_learning_control.algos.tf2.sac.sac import sac as sac_tf2

--- a/stable_learning_control/algos/pytorch/lac/__init__.py
+++ b/stable_learning_control/algos/pytorch/lac/__init__.py
@@ -1,3 +1,3 @@
-"""A Lyapunov Actor-Critic Agent.
+"""A Lyapunov (soft) Actor-Critic Agent.
 """
 from stable_learning_control.algos.pytorch.lac.lac import LAC, lac

--- a/stable_learning_control/algos/pytorch/latc/__init__.py
+++ b/stable_learning_control/algos/pytorch/latc/__init__.py
@@ -1,0 +1,3 @@
+"""A Lyapunov (soft) Actor-Twin Critic Agent.
+"""
+from stable_learning_control.algos.pytorch.latc.latc import latc

--- a/stable_learning_control/algos/pytorch/latc/latc.py
+++ b/stable_learning_control/algos/pytorch/latc/latc.py
@@ -1,0 +1,452 @@
+"""Lyapunov (soft) Actor-Twin Critic (LATC) algorithm.
+
+This is a modified version of the Lyapunov Actor-Critic algorithm of
+`Han et al. 2020 <https://arxiv.org/abs/2004.14288>`_. Like the original SAC algorithm,
+this LAC variant uses two critics instead of one to mitigate a possible underestimation
+bias, while the original LAC only uses one critic. For more information, see
+`Haarnoja et al. 2018 <https://arxiv.org/pdf/1812.05905.pdf>`_ or the
+:ref:`LATC documentation <latc>`.
+
+.. note::
+    Code Conventions:
+        -   We use a `_` suffix to distinguish the next state from the current state.
+        -   We use a `targ` suffix to distinguish actions/values coming from the target
+            network.
+
+.. attention::
+    To reduce the amount of code duplication, the code that implements the LATC algorithm
+    is found in the :class:`~stable_learning_control.algos.pytorch.lac.lac.LAC` class.
+    As a result this module wraps the :func:`~stable_learning_control.algos.pytorch.lac.lac.lac`
+    function so that it uses the :class:`~stable_learning_control.algos.pytorch.policies.lyapunov_actor_twin_critic.LyapunovActorTwinCritic`
+    as the actor-critic architecture. When this architecture is used, the
+    :meth:`~stable_learning_control.algos.pytorch.policies.lyapunov_actor_twin_critic.LyapunovActorTwinCritic.update`
+    method is modified such that the two critics.
+"""  # noqa: E501
+import argparse
+import os.path as osp
+import torch
+import gymnasium as gym
+import time
+
+from stable_learning_control.utils.safer_eval_util import safer_eval
+from stable_learning_control.algos.pytorch.lac.lac import lac
+from stable_learning_control.algos.pytorch.policies.lyapunov_actor_twin_critic import (
+    LyapunovActorTwinCritic,
+)
+from stable_learning_control.utils.log_utils.helpers import (
+    setup_logger_kwargs,
+)
+
+# Script settings.
+STD_OUT_LOG_VARS_DEFAULT = [
+    "Epoch",
+    "TotalEnvInteracts",
+    "AverageEpRet",
+    "AverageTestEpRet",
+    "AverageTestEpLen",
+    "AverageAlpha",
+    "AverageLambda",
+    "AverageLossAlpha",
+    "AverageLossLambda",
+    "AverageErrorL",
+    "AverageLossPi",
+    "AverageEntropy",
+]
+
+
+def latc(actor_critic=None, *args, **kwargs):
+    """Trains the LATC algorithm in a given environment.
+
+    .. note::
+        Wraps the :func:`~stable_learning_control.algos.pytorch.lac.lac.lac` function so
+        that the :class:`~stable_learning_control.algos.pytorch.policies.lyapunov_actor_twin_critic.LyapunovActorTwinCritic`
+        architecture is used as the actor critic.
+    """  # noqa: E501
+    # Get default actor critic if no 'actor_critic' was supplied
+    actor_critic = LyapunovActorTwinCritic if actor_critic is None else actor_critic
+
+    # Call lac algorithm.
+    return lac(actor_critic=actor_critic, *args, **kwargs)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Trains a LATC agent in a given environment."
+    )
+    parser.add_argument(
+        "--env",
+        type=str,
+        default="stable_gym:Oscillator-v1",
+        help="the gymnasium env (default: stable_gym:Oscillator-v1)",
+    )  # NOTE: Environment found in https://rickstaa.dev/stable-gym.
+    parser.add_argument(
+        "--hid_a",
+        type=int,
+        default=64,
+        help="hidden layer size of the actor (default: 64)",
+    )
+    parser.add_argument(
+        "--hid_c",
+        type=int,
+        default=128,
+        help="hidden layer size of the lyapunov critic (default: 128)",
+    )
+    parser.add_argument(
+        "--l_a",
+        type=int,
+        default=2,
+        help="number of hidden layer in the actor (default: 2)",
+    )
+    parser.add_argument(
+        "--l_c",
+        type=int,
+        default=2,
+        help="number of hidden layer in the critic (default: 2)",
+    )
+    parser.add_argument(
+        "--act_a",
+        type=str,
+        default="nn.ReLU",
+        help="the hidden layer activation function of the actor (default: nn.ReLU)",
+    )
+    parser.add_argument(
+        "--act_c",
+        type=str,
+        default="nn.ReLU",
+        help="the hidden layer activation function of the critic (default: nn.ReLU)",
+    )
+    parser.add_argument(
+        "--act_out_a",
+        type=str,
+        default="nn.ReLU",
+        help="the output activation function of the actor (default: nn.ReLU)",
+    )
+    parser.add_argument(
+        "--opt_type",
+        type=str,
+        default="minimize",
+        help="algorithm optimization type (default: minimize)",
+    )
+    parser.add_argument(
+        "--max_ep_len",
+        type=int,
+        default=None,
+        help="maximum episode length (default: None)",
+    )
+    parser.add_argument(
+        "--epochs", type=int, default=50, help="the number of epochs (default: 50)"
+    )
+    parser.add_argument(
+        "--steps_per_epoch",
+        type=int,
+        default=2048,
+        help="the number of steps per epoch (default: 2048)",
+    )
+    parser.add_argument(
+        "--start_steps",
+        type=int,
+        default=0,
+        help="the number of random exploration steps (default: 0)",
+    )
+    parser.add_argument(
+        "--update_every",
+        type=int,
+        default=100,
+        help=(
+            "the number of env interactions that should elapse between SGD updates "
+            "(default: 100)"
+        ),
+    )
+    parser.add_argument(
+        "--update_after",
+        type=int,
+        default=1000,
+        help="the number of steps before starting the SGD (default: 1000)",
+    )
+    parser.add_argument(
+        "--steps_per_update",
+        type=int,
+        default=100,
+        help=(
+            "the number of gradient descent steps that are"
+            "performed for each SGD update (default: 100)"
+        ),
+    )
+    parser.add_argument(
+        "--num_test_episodes",
+        type=int,
+        default=10,
+        help=(
+            "the number of episodes for the performance analysis (default: 10). When "
+            "set to zero no test episodes will be performed"
+        ),
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=0.99,
+        help="the entropy regularization coefficient (default: 0.99)",
+    )
+    parser.add_argument(
+        "--alpha3",
+        type=float,
+        default=0.2,
+        help="the Lyapunov constraint error boundary (default: 0.2)",
+    )
+    parser.add_argument(
+        "--labda",
+        type=float,
+        default=0.99,
+        help="the Lyapunov Lagrance multiplier (default: 0.99)",
+    )
+    parser.add_argument(
+        "--gamma", type=float, default=0.99, help="discount factor (default: 0.99)"
+    )
+    parser.add_argument(
+        "--polyak",
+        type=float,
+        default=0.995,
+        help="the interpolation factor in polyak averaging (default: 0.995)",
+    )
+    parser.add_argument(
+        "--target_entropy",
+        type=float,
+        default=None,
+        help="the initial target entropy (default: -action_space)",
+    )
+    parser.add_argument(
+        "--adaptive_temperature",
+        type=bool,
+        default=True,
+        help="the boolean for enabling automating Entropy Adjustment (default: True)",
+    )
+    parser.add_argument(
+        "--lr_a", type=float, default=1e-4, help="actor learning rate (default: 1e-4)"
+    )
+    parser.add_argument(
+        "--lr_c", type=float, default=3e-4, help="critic learning rate (default: 1e-4)"
+    )
+    parser.add_argument(
+        "--lr_a_final",
+        type=float,
+        default=1e-10,
+        help="the finalactor learning rate (default: 1e-10)",
+    )
+    parser.add_argument(
+        "--lr_c_final",
+        type=float,
+        default=1e-10,
+        help="the finalcritic learning rate (default: 1e-10)",
+    )
+    parser.add_argument(
+        "--lr_decay_type",
+        type=str,
+        default="linear",
+        help="the learning rate decay type (default: linear)",
+    )
+    parser.add_argument(
+        "--lr_decay_ref",
+        type=str,
+        default="epoch",
+        help=(
+            "the reference variable that is used for decaying the learning rate "
+            "'epoch' or 'step' (default: epoch)"
+        ),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=float,
+        default=256,
+        help="mini batch size of the SGD (default: 256)",
+    )
+    parser.add_argument(
+        "--replay-size",
+        type=int,
+        default=int(1e6),
+        help="replay buffer size (default: 1e6)",
+    )
+    parser.add_argument(
+        "--seed", "-s", type=int, default=0, help="the random seed (default: 0)"
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        help=(
+            "The device the networks are placed on: 'cpu' or 'gpu' (options: "
+            "default: cpu)"
+        ),
+    )
+    parser.add_argument(
+        "--start_policy",
+        type=str,
+        default=None,
+        help=(
+            "The policy which you want to use as the starting point for the training"
+            " (default: None)"
+        ),
+    )
+    parser.add_argument(
+        "--export",
+        type=str,
+        default=False,
+        help=(
+            "Whether you want to export the model as a 'TorchScript' such that "
+            "it can be deployed on hardware (default: False)"
+        ),
+    )
+
+    # Parse logger related arguments.
+    parser.add_argument(
+        "--exp_name",
+        type=str,
+        default="latc",
+        help="the name of the experiment (default: latc)",
+    )
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="suppress logging of diagnostics to stdout (default: False)",
+    )
+    parser.add_argument(
+        "--verbose_fmt",
+        type=str,
+        default="line",
+        help=(
+            "log diagnostics stdout format (options: 'table' or 'line', default: "
+            "line)"
+        ),
+    )
+    parser.add_argument(
+        "--verbose_vars",
+        nargs="+",
+        default=STD_OUT_LOG_VARS_DEFAULT,
+        help=("a space separated list of the values you want to show on the stdout."),
+    )
+    parser.add_argument(
+        "--save_freq",
+        type=int,
+        default=1,
+        help="how often (in epochs) the policy should be saved (default: 1)",
+    )
+    parser.add_argument(
+        "--save_checkpoints",
+        action="store_true",
+        help="use model checkpoints (default: False)",
+    )
+    parser.add_argument(
+        "--use_tensorboard",
+        action="store_true",
+        help="use TensorBoard (default: False)",
+    )
+    parser.add_argument(
+        "--tb_log_freq",
+        type=str,
+        default="low",
+        help=(
+            "the TensorBoard log frequency. Options are 'low' (Recommended: logs at "
+            "every epoch) and 'high' (logs at every SGD update batch). Default is 'low'"
+        ),
+    )
+    parser.add_argument(
+        "--use_wandb",
+        action="store_true",
+        help="use Weights & Biases (default: False)",
+    )
+    parser.add_argument(
+        "--wandb_job_type",
+        type=str,
+        default="train",
+        help="the Weights & Biases job type (default: train)",
+    )
+    parser.add_argument(
+        "--wandb_project",
+        type=str,
+        default="stable-learning-control",
+        help="the name of the wandb project (default: stable-learning-control)",
+    )
+    parser.add_argument(
+        "--wandb_group",
+        type=str,
+        default=None,
+        help=(
+            "the name of the Weights & Biases group you want to assign the run to "
+            "(defaults: None)"
+        ),
+    )
+    args = parser.parse_args()
+
+    # Setup actor critic arguments.
+    output_activation = {}
+    output_activation["actor"] = safer_eval(args.act_out_a, backend="torch")
+    ac_kwargs = dict(
+        hidden_sizes={
+            "actor": [args.hid_a] * args.l_a,
+            "critic": [args.hid_c] * args.l_c,
+        },
+        activation={
+            "actor": safer_eval(args.act_a, backend="torch"),
+            "critic": safer_eval(args.act_c, backend="torch"),
+        },
+        output_activation=output_activation,
+    )
+
+    # Setup output dir for logger and return output kwargs.
+    logger_kwargs = setup_logger_kwargs(
+        args.exp_name,
+        args.seed,
+        save_checkpoints=args.save_checkpoints,
+        use_tensorboard=args.use_tensorboard,
+        tb_log_freq=args.tb_log_freq,
+        use_wandb=args.use_wandb,
+        wandb_job_type=args.wandb_job_type,
+        wandb_project=args.wandb_project,
+        wandb_group=args.wandb_group,
+        quiet=args.quiet,
+        verbose_fmt=args.verbose_fmt,
+        verbose_vars=args.verbose_vars,
+    )
+    logger_kwargs["output_dir"] = osp.abspath(
+        osp.join(
+            osp.dirname(osp.realpath(__file__)),
+            f"../../../../../data/latc/{args.env.lower()}/runs/run_{int(time.time())}",
+        )
+    )
+    torch.set_num_threads(torch.get_num_threads())
+
+    lac(
+        lambda: gym.make(args.env),
+        actor_critic=LyapunovActorTwinCritic,
+        ac_kwargs=ac_kwargs,
+        opt_type=args.opt_type,
+        max_ep_len=args.max_ep_len,
+        epochs=args.epochs,
+        steps_per_epoch=args.steps_per_epoch,
+        start_steps=args.start_steps,
+        update_every=args.update_every,
+        update_after=args.update_after,
+        steps_per_update=args.steps_per_update,
+        num_test_episodes=args.num_test_episodes,
+        alpha=args.alpha,
+        alpha3=args.alpha3,
+        labda=args.labda,
+        gamma=args.gamma,
+        polyak=args.polyak,
+        target_entropy=args.target_entropy,
+        adaptive_temperature=args.adaptive_temperature,
+        lr_a=args.lr_a,
+        lr_c=args.lr_c,
+        lr_a_final=args.lr_a_final,
+        lr_c_final=args.lr_c_final,
+        lr_decay_type=args.lr_decay_type,
+        lr_decay_ref=args.lr_decay_ref,
+        batch_size=args.batch_size,
+        replay_size=args.replay_size,
+        seed=args.seed,
+        save_freq=args.save_freq,
+        device=args.device,
+        start_policy=args.start_policy,
+        export=args.export,
+        logger_kwargs=logger_kwargs,
+    )

--- a/stable_learning_control/algos/pytorch/policies/__init__.py
+++ b/stable_learning_control/algos/pytorch/policies/__init__.py
@@ -11,3 +11,6 @@ from stable_learning_control.algos.pytorch.policies.lyapunov_actor_critic import
 from stable_learning_control.algos.pytorch.policies.soft_actor_critic import (
     SoftActorCritic,
 )
+from stable_learning_control.algos.pytorch.policies.lyapunov_actor_twin_critic import (
+    LyapunovActorTwinCritic,
+)

--- a/stable_learning_control/algos/pytorch/sac/sac.py
+++ b/stable_learning_control/algos/pytorch/sac/sac.py
@@ -1,4 +1,4 @@
-"""Soft Actor-Critic algorithm
+"""Soft Actor-Critic (SAC) algorithm.
 
 This module contains the Pytorch implementation of the SAC algorithm of
 `Haarnoja et al. 2019 <https://arxiv.org/abs/1812.05905>`_.
@@ -55,8 +55,8 @@ from stable_learning_control.utils.serialization_utils import save_to_json
 SCALE_LAMBDA_MIN_MAX = (
     0.0,
     1.0,
-)  # Range of lambda lagrance multiplier.
-SCALE_ALPHA_MIN_MAX = (0.0, np.inf)  # Range of alpha lagrance multiplier.
+)  # Range of lambda Lagrance multiplier.
+SCALE_ALPHA_MIN_MAX = (0.0, np.inf)  # Range of alpha Lagrance multiplier.
 STD_OUT_LOG_VARS_DEFAULT = [
     "Epoch",
     "TotalEnvInteracts",
@@ -78,7 +78,7 @@ class SAC(nn.Module):
     Attributes:
         ac (torch.nn.Module): The soft actor critic module.
         ac_ (torch.nn.Module): The target soft actor critic module.
-        log_alpha (torch.Tensor): The temperature lagrance multiplier.
+        log_alpha (torch.Tensor): The temperature Lagrance multiplier.
         target_entropy (int): The target entropy.
         device (str): The device the networks are placed on (``cpu`` or ``gpu``).
             Defaults to ``cpu``.
@@ -357,7 +357,7 @@ class SAC(nn.Module):
         q1 = self.ac.Q1(o, a)
         q2 = self.ac.Q2(o, a)
 
-        # Calculate Q-critic MSE loss against Bellman backup
+        # Calculate Q-critic MSE loss against Bellman backup.
         loss_q1 = 0.5 * ((q1 - q_backup) ** 2).mean()  # See Haarnoja eq. 5
         loss_q2 = 0.5 * ((q2 - q_backup) ** 2).mean()
         q_loss = loss_q1 + loss_q2
@@ -387,9 +387,13 @@ class SAC(nn.Module):
         q1_pi = self.ac.Q1(o, pi)
         q2_pi = self.ac.Q2(o, pi)
         if self._opt_type.lower() == "minimize":
-            q_pi = torch.max(q1_pi, q2_pi)
+            q_pi = torch.max(
+                q1_pi, q2_pi
+            )  # Use max clipping to prevent underestimation bias.
         else:
-            q_pi = torch.min(q1_pi, q2_pi)
+            q_pi = torch.min(
+                q1_pi, q2_pi
+            )  # Use min clipping to prevent overestimation bias.
 
         # Calculate entropy-regularized policy loss
         if self._opt_type.lower() == "minimize":
@@ -474,7 +478,7 @@ class SAC(nn.Module):
             path (str): The path where the model :attr:`state_dict` of the policy is
                 found.
             restore_lagrance_multipliers (bool, optional): Whether you want to restore
-                the lagrance multipliers. By fault ``False``.
+                the Lagrance multipliers. By fault ``False``.
 
         Raises:
             Exception: Raises an exception if something goes wrong during loading.
@@ -546,7 +550,7 @@ class SAC(nn.Module):
             state_dict (dict): a dict containing parameters and
                 persistent buffers.
             restore_lagrance_multipliers (bool, optional): Whether you want to restore
-                the lagrance multipliers. By fault ``True``.
+                the Lagrance multipliers. By fault ``True``.
         """
         if (
             "alg_name" in self.state_dict()
@@ -578,14 +582,14 @@ class SAC(nn.Module):
             )
         if not restore_lagrance_multipliers:
             log_to_std_out(
-                "Keeping lagrance multipliers at their initial value.", type="info"
+                "Keeping Lagrance multipliers at their initial value.", type="info"
             )
             try:
                 del state_dict["log_alpha"]
             except KeyError:
                 pass
         else:
-            log_to_std_out("Restoring lagrance multipliers.", type="info")
+            log_to_std_out("Restoring Lagrance multipliers.", type="info")
 
         try:
             super().load_state_dict(state_dict, strict=False)
@@ -610,11 +614,11 @@ class SAC(nn.Module):
 
         Args:
             lr_a_final (float, optional): The lower bound for the actor learning rate.
-                Defaults to None.
+                Defaults to ``None``.
             lr_c_final (float, optional): The lower bound for the critic learning rate.
-                Defaults to None.
+                Defaults to ``None``.
             lr_alpha_final (float, optional): The lower bound for the alpha Lagrance
-                multiplier learning rate. Defaults to None.
+                multiplier learning rate. Defaults to ``None``.
         """
         if lr_a_final is not None:
             if self._pi_optimizer.param_groups[0]["lr"] < lr_a_final:
@@ -643,11 +647,11 @@ class SAC(nn.Module):
 
         Args:
             lr_a (float, optional): The learning rate of the actor optimizer. Defaults
-                to None.
+                to ``None``.
             lr_c (float, optional): The learning rate of the (soft) Critic. Defaults
-                to None.
+                to ``None``.
             lr_alpha (float, optional): The learning rate of the temperature optimizer.
-                Defaults to None.
+                Defaults to ``None``.
         """
         if lr_a:
             self._pi_optimizer.param_groups[0]["lr"] = lr_a
@@ -755,7 +759,7 @@ def sac(
     start_policy=None,
     export=False,
 ):
-    """Trains the sac algorithm in a given environment.
+    """Trains the SAC algorithm in a given environment.
 
     Args:
         env_fn: A function which creates a copy of the environment.

--- a/stable_learning_control/algos/tf2/latc/__init__.py
+++ b/stable_learning_control/algos/tf2/latc/__init__.py
@@ -1,0 +1,3 @@
+"""A Lyapunov (soft) Actor-Twin Critic Agent.
+"""
+from stable_learning_control.algos.tf2.latc.latc import latc

--- a/stable_learning_control/algos/tf2/latc/latc.py
+++ b/stable_learning_control/algos/tf2/latc/latc.py
@@ -1,0 +1,452 @@
+"""Lyapunov (soft) Actor-Twin Critic (LATC) algorithm.
+
+This is a modified version of the Lyapunov Actor-Critic algorithm of
+`Han et al. 2020 <https://arxiv.org/abs/2004.14288>`_. Like the original SAC algorithm,
+this LAC variant uses two critics instead of one to mitigate a possible underestimation
+bias, while the original LAC only uses one critic. For more information, see
+`Haarnoja et al. 2018 <https://arxiv.org/pdf/1812.05905.pdf>`_ or the
+:ref:`LATC documentation <latc>`.
+
+.. note::
+    Code Conventions:
+        -   We use a `_` suffix to distinguish the next state from the current state.
+        -   We use a `targ` suffix to distinguish actions/values coming from the target
+            network.
+
+.. attention::
+    To reduce the amount of code duplication, the code that implements the LATC algorithm
+    is found in the :class:`~stable_learning_control.algos.tf2.lac.lac.LAC` class.
+    As a result this module wraps the
+    :func:`~stable_learning_control.algos.tf2.lac.lac.lac` function so that it uses
+    the :class:`~stable_learning_control.algos.tf2.policies.lyapunov_actor_twin_critic.LyapunovActorTwinCritic`
+    as the actor-critic architecture. When this architecture is used, the
+    :meth:`~stable_learning_control.algos.tf2.policies.lyapunov_actor_twin_critic.LyapunovActorTwinCritic.update`
+    method is modified such that the two critics.
+"""  # noqa: E501
+import argparse
+import os.path as osp
+import time
+
+import gymnasium as gym
+
+from stable_learning_control.algos.tf2.lac.lac import lac
+from stable_learning_control.algos.tf2.policies.lyapunov_actor_twin_critic import (
+    LyapunovActorTwinCritic,
+)
+from stable_learning_control.utils.log_utils.helpers import setup_logger_kwargs
+from stable_learning_control.utils.safer_eval_util import safer_eval
+
+# Script settings.
+STD_OUT_LOG_VARS_DEFAULT = [
+    "Epoch",
+    "TotalEnvInteracts",
+    "AverageEpRet",
+    "AverageTestEpRet",
+    "AverageTestEpLen",
+    "AverageAlpha",
+    "AverageLambda",
+    "AverageLossAlpha",
+    "AverageLossLambda",
+    "AverageErrorL",
+    "AverageLossPi",
+    "AverageEntropy",
+]
+
+# tf.config.run_functions_eagerly(True)  # NOTE: Uncomment for debugging.
+
+
+def latc(actor_critic=None, *args, **kwargs):
+    """Trains the LATC algorithm in a given environment.
+
+    .. note::
+        Wraps the :func:`~stable_learning_control.algos.tf2.lac.lac.lac` function so
+        that the :class:`~stable_learning_control.algos.tf2.policies.lyapunov_actor_twin_critic.LyapunovActorTwinCritic`
+        architecture is used as the actor critic.
+    """  # noqa: E501
+    # Get default actor critic if no 'actor_critic' was supplied
+    actor_critic = LyapunovActorTwinCritic if actor_critic is None else actor_critic
+
+    # Call lac algorithm.
+    return lac(actor_critic=actor_critic, *args, **kwargs)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Trains a LATC agent in a given environment."
+    )
+    parser.add_argument(
+        "--env",
+        type=str,
+        default="stable_gym:Oscillator-v1",
+        help="the gymnasium env (default: stable_gym:Oscillator-v1)",
+    )  # NOTE: Environment found in https://rickstaa.dev/stable-gym.
+    parser.add_argument(
+        "--hid_a",
+        type=int,
+        default=64,
+        help="hidden layer size of the actor (default: 64)",
+    )
+    parser.add_argument(
+        "--hid_c",
+        type=int,
+        default=128,
+        help="hidden layer size of the lyapunov critic (default: 128)",
+    )
+    parser.add_argument(
+        "--l_a",
+        type=int,
+        default=2,
+        help="number of hidden layer in the actor (default: 2)",
+    )
+    parser.add_argument(
+        "--l_c",
+        type=int,
+        default=2,
+        help="number of hidden layer in the critic (default: 2)",
+    )
+    parser.add_argument(
+        "--act_a",
+        type=str,
+        default="nn.relu",
+        help="the hidden layer activation function of the actor (default: nn.relu)",
+    )
+    parser.add_argument(
+        "--act_c",
+        type=str,
+        default="nn.relu",
+        help="the hidden layer activation function of the critic (default: nn.relu)",
+    )
+    parser.add_argument(
+        "--act_out_a",
+        type=str,
+        default="nn.relu",
+        help="the output activation function of the actor (default: nn.relu)",
+    )
+    parser.add_argument(
+        "--opt_type",
+        type=str,
+        default="minimize",
+        help="algorithm optimization type (default: minimize)",
+    )
+    parser.add_argument(
+        "--max_ep_len",
+        type=int,
+        default=None,
+        help="maximum episode length (default: None)",
+    )
+    parser.add_argument(
+        "--epochs", type=int, default=50, help="the number of epochs (default: 50)"
+    )
+    parser.add_argument(
+        "--steps_per_epoch",
+        type=int,
+        default=2048,
+        help="the number of steps per epoch (default: 2048)",
+    )
+    parser.add_argument(
+        "--start_steps",
+        type=int,
+        default=0,
+        help="the number of random exploration steps (default: 0)",
+    )
+    parser.add_argument(
+        "--update_every",
+        type=int,
+        default=100,
+        help=(
+            "the number of env interactions that should elapse between SGD updates "
+            "(default: 100)"
+        ),
+    )
+    parser.add_argument(
+        "--update_after",
+        type=int,
+        default=1000,
+        help="the number of steps before starting the SGD (default: 1000)",
+    )
+    parser.add_argument(
+        "--steps_per_update",
+        type=int,
+        default=100,
+        help=(
+            "the number of gradient descent steps that are"
+            "performed for each SGD update (default: 100)"
+        ),
+    )
+    parser.add_argument(
+        "--num_test_episodes",
+        type=int,
+        default=10,
+        help=(
+            "the number of episodes for the performance analysis (default: 10). When "
+            "set to zero no test episodes will be performed"
+        ),
+    )
+    parser.add_argument(
+        "--alpha",
+        type=float,
+        default=0.99,
+        help="the entropy regularization coefficient (default: 0.99)",
+    )
+    parser.add_argument(
+        "--alpha3",
+        type=float,
+        default=0.2,
+        help="the Lyapunov constraint error boundary (default: 0.2)",
+    )
+    parser.add_argument(
+        "--labda",
+        type=float,
+        default=0.99,
+        help="the Lyapunov Lagrance multiplier (default: 0.99)",
+    )
+    parser.add_argument(
+        "--gamma", type=float, default=0.99, help="discount factor (default: 0.99)"
+    )
+    parser.add_argument(
+        "--polyak",
+        type=float,
+        default=0.995,
+        help="the interpolation factor in polyak averaging (default: 0.995)",
+    )
+    parser.add_argument(
+        "--target_entropy",
+        type=float,
+        default=None,
+        help="the initial target entropy (default: -action_space)",
+    )
+    parser.add_argument(
+        "--adaptive_temperature",
+        type=bool,
+        default=True,
+        help="the boolean for enabling automating Entropy Adjustment (default: True)",
+    )
+    parser.add_argument(
+        "--lr_a", type=float, default=1e-4, help="actor learning rate (default: 1e-4)"
+    )
+    parser.add_argument(
+        "--lr_c", type=float, default=3e-4, help="critic learning rate (default: 1e-4)"
+    )
+    parser.add_argument(
+        "--lr_a_final",
+        type=float,
+        default=1e-10,
+        help="the finalactor learning rate (default: 1e-10)",
+    )
+    parser.add_argument(
+        "--lr_c_final",
+        type=float,
+        default=1e-10,
+        help="the finalcritic learning rate (default: 1e-10)",
+    )
+    parser.add_argument(
+        "--lr_decay_type",
+        type=str,
+        default="linear",
+        help="the learning rate decay type (default: linear)",
+    )
+    parser.add_argument(
+        "--lr_decay_ref",
+        type=str,
+        default="epoch",
+        help=(
+            "the reference variable that is used for decaying the learning rate "
+            "'epoch' or 'step' (default: epoch)"
+        ),
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=float,
+        default=256,
+        help="mini batch size of the SGD (default: 256)",
+    )
+    parser.add_argument(
+        "--replay-size",
+        type=int,
+        default=int(1e6),
+        help="replay buffer size (default: 1e6)",
+    )
+    parser.add_argument(
+        "--seed", "-s", type=int, default=0, help="the random seed (default: 0)"
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        help=(
+            "The device the networks are placed on: 'cpu' or 'gpu' (options: "
+            "default: cpu)"
+        ),
+    )
+    parser.add_argument(
+        "--start_policy",
+        type=str,
+        default=None,
+        help=(
+            "The policy which you want to use as the starting point for the training"
+            " (default: None)"
+        ),
+    )
+    parser.add_argument(
+        "--export",
+        type=str,
+        default=False,
+        help=(
+            "Whether you want to export the model in the 'SavedModel' format "
+            "such that it can be deployed to hardware (Default: False)"
+        ),
+    )
+
+    # Parse logger related arguments.
+    parser.add_argument(
+        "--exp_name",
+        type=str,
+        default="lac",
+        help="the name of the experiment (default: lac)",
+    )
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="suppress logging of diagnostics to stdout (default: False)",
+    )
+    parser.add_argument(
+        "--verbose_fmt",
+        type=str,
+        default="line",
+        help=(
+            "log diagnostics stdout format (options: 'table' or 'line', default: "
+            "line)"
+        ),
+    )
+    parser.add_argument(
+        "--verbose_vars",
+        nargs="+",
+        default=STD_OUT_LOG_VARS_DEFAULT,
+        help=("a space separated list of the values you want to show on the stdout."),
+    )
+    parser.add_argument(
+        "--save_freq",
+        type=int,
+        default=1,
+        help="how often (in epochs) the policy should be saved (default: 1)",
+    )
+    parser.add_argument(
+        "--save_checkpoints",
+        action="store_true",
+        help="use model checkpoints (default: False)",
+    )
+    parser.add_argument(
+        "--use_tensorboard",
+        action="store_true",
+        help="use TensorBoard (default: False)",
+    )
+    parser.add_argument(
+        "--tb_log_freq",
+        type=str,
+        default="low",
+        help=(
+            "the TensorBoard log frequency. Options are 'low' (Recommended: logs at "
+            "every epoch) and 'high' (logs at every SGD update batch). Default is 'low'"
+        ),
+    )
+    parser.add_argument(
+        "--use_wandb",
+        action="store_true",
+        help="use Weights & Biases (default: False)",
+    )
+    parser.add_argument(
+        "--wandb_job_type",
+        type=str,
+        default="train",
+        help="the Weights & Biases job type (default: train)",
+    )
+    parser.add_argument(
+        "--wandb_project",
+        type=str,
+        default="stable-learning-control",
+        help="the name of the wandb project (default: stable-learning-control)",
+    )
+    parser.add_argument(
+        "--wandb_group",
+        type=str,
+        default=None,
+        help=(
+            "the name of the Weights & Biases group you want to assign the run to "
+            "(defaults: None)"
+        ),
+    )
+    args = parser.parse_args()
+
+    # Setup actor critic arguments.
+    output_activation = {}
+    output_activation["actor"] = safer_eval(args.act_out_a, backend="tf2")
+    ac_kwargs = dict(
+        hidden_sizes={
+            "actor": [args.hid_a] * args.l_a,
+            "critic": [args.hid_c] * args.l_c,
+        },
+        activation={
+            "actor": safer_eval(args.act_a, backend="tf2"),
+            "critic": safer_eval(args.act_c, backend="tf2"),
+        },
+        output_activation=output_activation,
+    )
+
+    # Setup output dir for logger and return output kwargs.
+    logger_kwargs = setup_logger_kwargs(
+        args.exp_name,
+        args.seed,
+        save_checkpoints=args.save_checkpoints,
+        use_tensorboard=args.use_tensorboard,
+        tb_log_freq=args.tb_log_freq,
+        use_wandb=args.use_wandb,
+        wandb_job_type=args.wandb_job_type,
+        wandb_project=args.wandb_project,
+        wandb_group=args.wandb_group,
+        quiet=args.quiet,
+        verbose_fmt=args.verbose_fmt,
+        verbose_vars=args.verbose_vars,
+    )
+    logger_kwargs["output_dir"] = osp.abspath(
+        osp.join(
+            osp.dirname(osp.realpath(__file__)),
+            f"../../../../../data/lac/{args.env.lower()}/runs/run_{int(time.time())}",
+        )
+    )
+
+    lac(
+        lambda: gym.make(args.env),
+        actor_critic=LyapunovActorTwinCritic,
+        ac_kwargs=ac_kwargs,
+        opt_type=args.opt_type,
+        max_ep_len=args.max_ep_len,
+        epochs=args.epochs,
+        steps_per_epoch=args.steps_per_epoch,
+        start_steps=args.start_steps,
+        update_every=args.update_every,
+        update_after=args.update_after,
+        steps_per_update=args.steps_per_update,
+        num_test_episodes=args.num_test_episodes,
+        alpha=args.alpha,
+        alpha3=args.alpha3,
+        labda=args.labda,
+        gamma=args.gamma,
+        polyak=args.polyak,
+        target_entropy=args.target_entropy,
+        adaptive_temperature=args.adaptive_temperature,
+        lr_a=args.lr_a,
+        lr_c=args.lr_c,
+        lr_a_final=args.lr_a_final,
+        lr_c_final=args.lr_c_final,
+        lr_decay_type=args.lr_decay_type,
+        lr_decay_ref=args.lr_decay_ref,
+        batch_size=args.batch_size,
+        replay_size=args.replay_size,
+        seed=args.seed,
+        save_freq=args.save_freq,
+        device=args.device,
+        start_policy=args.start_policy,
+        export=args.export,
+        logger_kwargs=logger_kwargs,
+    )

--- a/stable_learning_control/algos/tf2/policies/__init__.py
+++ b/stable_learning_control/algos/tf2/policies/__init__.py
@@ -9,3 +9,6 @@ from stable_learning_control.algos.tf2.policies.lyapunov_actor_critic import (
     LyapunovActorCritic,
 )
 from stable_learning_control.algos.tf2.policies.soft_actor_critic import SoftActorCritic
+from stable_learning_control.algos.tf2.policies.lyapunov_actor_twin_critic import (
+    LyapunovActorTwinCritic,
+)

--- a/stable_learning_control/algos/tf2/policies/lyapunov_actor_twin_critic.py
+++ b/stable_learning_control/algos/tf2/policies/lyapunov_actor_twin_critic.py
@@ -1,0 +1,176 @@
+"""Lyapunov (soft) Actor-Twin critic policy.
+
+This module contains a modified Pytorch implementation of the Lyapunov Actor-Critic
+policy of `Han et al. 2020 <https://arxiv.org/abs/2004.14288>`_. Like the original SAC
+algorithm, this LAC variant uses two critics instead of one to mitigate a possible
+underestimation bias, while the original LAC only uses one critic.
+"""
+import tensorflow as tf
+from tensorflow import nn
+
+from stable_learning_control.algos.tf2.policies.actors.squashed_gaussian_actor import (
+    SquashedGaussianActor,
+)
+from stable_learning_control.algos.tf2.policies.critics.L_critic import LCritic
+from stable_learning_control.common.helpers import strict_dict_update
+from stable_learning_control.utils.log_utils.helpers import log_to_std_out
+
+HIDDEN_SIZES_DEFAULT = {"actor": (64, 64), "critic": (128, 128)}
+ACTIVATION_DEFAULT = {"actor": nn.relu, "critic": nn.relu}
+OUTPUT_ACTIVATION_DEFAULT = {
+    "actor": nn.relu,
+}
+
+
+class LyapunovActorTwinCritic(tf.keras.Model):
+    """Lyapunov (soft) Actor-Twin Critic network.
+
+    Attributes:
+        self.pi (:class:`~stable_learning_control.algos.tf2.policies.actors.squashed_gaussian_actor.SquashedGaussianActor`):
+            The squashed gaussian policy network (actor).
+        self.L (:obj:`~stable_learning_control.algos.tf2.policies.critics.L_critic.LCritic`):
+            The soft L-network (critic).
+        self.L2 (:obj:`~stable_learning_control.algos.tf2.policies.critics.L_critic.LCritic`):
+            The second soft L-network (critic).
+    """  # noqa: E501
+
+    def __init__(
+        self,
+        observation_space,
+        action_space,
+        hidden_sizes=HIDDEN_SIZES_DEFAULT,
+        activation=ACTIVATION_DEFAULT,
+        output_activation=OUTPUT_ACTIVATION_DEFAULT,
+        name="lyapunov_actor_critic",
+    ):
+        """Initialise the LyapunovActorTwinCritic object.
+
+        Args:
+            observation_space (:obj:`gym.space.box.Box`): A gymnasium observation space.
+            action_space (:obj:`gym.space.box.Box`): A gymnasium action space.
+            hidden_sizes (Union[dict, tuple, list], optional): Sizes of the hidden
+                layers for the actor. Defaults to ``(256, 256)``.
+            activation (Union[:obj:`dict`, :obj:`tf.keras.activations`], optional): The
+                (actor and critic) hidden layers activation function. Defaults to
+                :obj:`tf.nn.relu`.
+            output_activation (Union[:obj:`dict`, :obj:`tf.keras.activations`], optional):
+                The actor  output activation function. Defaults to :obj:`tf.nn.relu`.
+            name (str, optional): The name given to the LyapunovActorCritic. Defaults to
+                "lyapunov_actor_critic".
+
+        .. note::
+            It is currently not possible to set the critic output activation function
+            when using the LyapunovActorTwinCritic. This is since it by design requires the
+            critic output activation to by of type :meth:`tf.math.square`.
+        """  # noqa: E501
+        super().__init__(name=name)
+        obs_dim = observation_space.shape[0]
+        act_dim = action_space.shape[0]
+
+        # Parse hidden sizes, activation inputs arguments and action_limits
+        hidden_sizes, _ = strict_dict_update(HIDDEN_SIZES_DEFAULT, hidden_sizes)
+        activation, _ = strict_dict_update(ACTIVATION_DEFAULT, activation)
+        output_activation, ignored = strict_dict_update(
+            OUTPUT_ACTIVATION_DEFAULT, output_activation
+        )
+        act_limits = {"low": action_space.low, "high": action_space.high}
+
+        if "critic" in ignored:
+            log_to_std_out(
+                (
+                    "The critic output activation function was ignored since it can "
+                    "not be set using the LyapunovActorTwinCritic architecture. This is "
+                    "since it, by design, uses the 'tf.math.square' output activation "
+                    "function."
+                ),
+                type="warning",
+            )
+
+        self.pi = SquashedGaussianActor(
+            obs_dim=obs_dim,
+            act_dim=act_dim,
+            hidden_sizes=hidden_sizes["actor"],
+            activation=activation["actor"],
+            output_activation=output_activation["actor"],
+            act_limits=act_limits,
+        )
+        self.L = LCritic(
+            obs_dim=obs_dim,
+            act_dim=act_dim,
+            hidden_sizes=hidden_sizes["critic"],
+            activation=activation["critic"],
+        )
+        self.L2 = LCritic(
+            obs_dim=obs_dim,
+            act_dim=act_dim,
+            hidden_sizes=hidden_sizes["critic"],
+            activation=activation["critic"],
+        )
+
+        # Perform one forward pass to initialise the networks.
+        # NOTE: Done because TF doesn't support multiple positional arguments when using
+        # the tf.function decorator, and autograph doesn't support list unpacking.
+        obs_dummy = tf.random.uniform((1, obs_dim), dtype=tf.float32)
+        act_dummy = tf.random.uniform((1, act_dim), dtype=tf.float32)
+        self([obs_dummy, act_dummy])
+
+    @tf.function
+    def call(self, inputs, deterministic=False, with_logprob=True):
+        """Performs a forward pass through all the networks (Actor and both  L critics).
+
+        Args:
+            inputs (tuple): tuple containing:
+
+                -   obs (tf.Tensor): The tensor of observations.
+                -   act (tf.Tensor): The tensor of actions.
+
+            deterministic (bool, optional): Whether we want to use a deterministic
+                policy (used at test time). When true the mean action of the stochastic
+                policy is returned. If false the action is sampled from the stochastic
+                policy. Defaults to ``False``.
+            with_logprob (bool, optional): Whether we want to return the log probability
+                of an action. Defaults to ``True``.
+
+        Returns:
+            (tuple): tuple containing:
+
+                - pi_action (:obj:`tf.Tensor`): The actions given by the policy.
+                - logp_pi (:obj:`tf.Tensor`): The log probabilities of each of these actions.
+                - L (:obj:`tf.Tensor`): First critic L values.
+                - L2 (:obj:`tf.Tensor`): Second critic L values.
+
+        .. note::
+            Useful for when you want to print out the full network graph using
+            TensorBoard.
+        """  # noqa: E501
+        obs, act = inputs
+        pi_action, logp_pi = self.pi(
+            obs, deterministic=deterministic, with_logprob=with_logprob
+        )
+        L = self.L([obs, act])
+        L2 = self.L2([obs, act])
+        return pi_action, logp_pi, L, L2
+
+    @tf.function
+    def act(self, obs, deterministic=False):
+        """Returns the action from the current state given the current policy.
+
+        Args:
+            obs (numpy.ndarray): The current observation (state).
+            deterministic (bool, optional): Whether we want to use a deterministic
+                policy (used at test time). When true the mean action of the stochastic
+                policy is returned. If ``False`` the action is sampled from the
+                stochastic policy. Defaults to ``False``.
+
+        Returns:
+            numpy.ndarray: The action from the current state given the current policy.
+        """
+        # Make sure the batch dimension is present (Required by tf.keras.layers.Dense)
+        if obs.shape.ndims == 1:
+            obs = tf.reshape(obs, (1, -1))
+
+        a, _ = self.pi(obs, deterministic, False)
+
+        return tf.squeeze(
+            a, axis=0
+        )  # NOTE: Squeeze is critical to ensure a has right shape.

--- a/stable_learning_control/common/helpers.py
+++ b/stable_learning_control/common/helpers.py
@@ -80,19 +80,30 @@ def get_unique_list(input_list, trim=True):
         return list({item for item in input_list})
 
 
-def combine_shapes(*args):
+def combine_shapes(*args, remove_none=False):
     """Combines multiple tuples/ints/floats into one tuple.
 
     Args:
-        *args (Union[tuple,int,float]): Input arguments to combine
+        *args (Union[tuple,int,float]): Input arguments to combine.
+        remove_none (bool, optional): Remove ``None`` values from the resulting tuple.
 
     Returns:
         Tuple: A tuple in which al the input arguments are combined.
     """
-    return tuple(
+    combined_tuple = tuple(
         itertools.chain(
-            *[[item] if isinstance(item, (int, float)) else list(item) for item in args]
+            *[
+                [item]
+                if (isinstance(item, (int, float)) or item is None)
+                else list(item)
+                for item in args
+            ]
         )
+    )
+    return (
+        combined_tuple
+        if not remove_none
+        else tuple([item for item in combined_tuple if item is not None])
     )
 
 

--- a/stable_learning_control/disturbers/__init__.py
+++ b/stable_learning_control/disturbers/__init__.py
@@ -1,7 +1,6 @@
 """Contains the disturbers that are available in the SLC package.
 
 .. note::
-
     These disturbers are implemented as gymnasium:`gymnasium wrappers <api/wrappers/>`.
     Because of this, they can be used with any :gymnasium:`gymnasium environment <>`. If
     you want to add a new disturber, you only have to ensure that it is a Python class

--- a/stable_learning_control/run.py
+++ b/stable_learning_control/run.py
@@ -60,7 +60,7 @@ SUBSTITUTIONS = {
 MPI_COMPATIBLE_ALGOS = []
 
 # Algo names (used in a few places).
-BASE_ALGO_NAMES = ["sac", "lac"]
+BASE_ALGO_NAMES = ["sac", "lac", "latc"]
 
 
 def _parse_hyperparameter_variants(exp_val):
@@ -96,7 +96,6 @@ def _parse_exp_cfg(cmd_line_args):
             that were specified in a experimental cfg file.
 
     .. note::
-
         This function assumes comma/space separated strings (i.e. ``5, 3, 2`` or
         ``5 3 2``)) to be hyperparmeter variants.
     """
@@ -213,7 +212,6 @@ def _parse_eval_cfg(cmd_line_args):
             that were specified in a eval cfg file.
 
     .. note::
-
         This function assumes comma/space separated strings (i.e. ``5, 3, 2`` or
         ``5 3 2``)) to be hyperparmeter variants.
     """

--- a/stable_learning_control/user_config.py
+++ b/stable_learning_control/user_config.py
@@ -10,6 +10,7 @@ import os.path as osp
 # Default neural network backend for each algo (Must be either 'tf2' or 'pytorch').
 DEFAULT_BACKEND = {
     "lac": "pytorch",
+    "latc": "pytorch",
     "sac": "pytorch",
 }
 

--- a/stable_learning_control/utils/log_utils/logx.py
+++ b/stable_learning_control/utils/log_utils/logx.py
@@ -668,7 +668,7 @@ class Logger:
             state_dict (dict): Dictionary containing essential elements to
                 describe the current state of training.
             itr (Union[int, None]): Current iteration of training (e.g. epoch). Defaults
-                to None
+                to ``None``.
         """
         if proc_id() == 0:
             # Save training state (environment, ...)
@@ -730,7 +730,7 @@ class Logger:
 
         Args:
             itr (Union[int, None]): Current iteration of training (e.g. epoch). Defaults
-                to None
+                to ``None``.
         """
         if proc_id() == 0:
             save_fail_warning = (
@@ -802,7 +802,7 @@ class Logger:
 
         Args:
             itr (Union[int, None]): Current iteration of training (e.g. epoch). Defaults
-                to None
+                to ``None``.
         """
         if proc_id() == 0:
             save_fail_warning = (

--- a/stable_learning_control/utils/run_utils.py
+++ b/stable_learning_control/utils/run_utils.py
@@ -63,7 +63,7 @@ def call_experiment(
             'auto', which will set up as many procs as there are cpus on
             the machine.
         data_dir (str): Used in configuring the logger, to decide where
-            to store experiment results. Note: if left as None, data_dir will
+            to store experiment results. Note: if left as ``None``, data_dir will
             default to ``DEFAULT_DATA_DIR`` from
             :mod:`stable_learning_control.user_config`.
         datestamp (bool): Whether a datestamp should be added to the experiment name.
@@ -487,7 +487,7 @@ class ExperimentGrid:
                 'auto', which will set up as many procs as there are cpus on
                 the machine.
             data_dir (str): Used in configuring the logger, to decide where
-                to store experiment results. Note: if left as None, data_dir will
+                to store experiment results. Note: if left as ``None``, data_dir will
                 default to ``DEFAULT_DATA_DIR`` from
                 :mod:`stable_learning_control.user_config`.
             datestamp (bool): Whether a datestamp should be added to the experiment

--- a/stable_learning_control/utils/test_policy.py
+++ b/stable_learning_control/utils/test_policy.py
@@ -265,7 +265,7 @@ def run_policy(
     Args:
         env (:obj:`gym.env`): The gymnasium environment.
         policy (Union[tf.keras.Model, torch.nn.Module]): The policy.
-        max_ep_len (int, optional): The maximum episode length. Defaults to None.
+        max_ep_len (int, optional): The maximum episode length. Defaults to ``None``.
         num_episodes (int, optional): Number of episodes you want to perform in the
             environment. Defaults to 100.
         deterministic (bool, optional): Whether you want the action from the policy to


### PR DESCRIPTION
This pull request adds the LATC algorithm. The Laypunov Actor-Twin Critic (LATC) algorithm is a successor to the LAC algorithm. In contrast to its predecessor, the LATC algorithm employs a dual-critic approach, aligning it more closely with the SAC algorithm upon which LAC was built initially.
