### PR TITLE
feat(wandb): add 'wandb_run_name' argument

### DIFF
--- a/stable_learning_control/algos/pytorch/lac/lac.py
+++ b/stable_learning_control/algos/pytorch/lac/lac.py
@@ -1731,6 +1731,15 @@ if __name__ == "__main__":
             "(defaults: None)"
         ),
     )
+    parser.add_argument(
+        "--wandb_run_name",
+        type=str,
+        default=None,
+        help=(
+            "the name of the Weights & Biases run (defaults: None, which will be "
+            "set to the experiment name)"
+        ),
+    )
     args = parser.parse_args()
 
     # Setup actor critic arguments.
@@ -1759,6 +1768,7 @@ if __name__ == "__main__":
         wandb_job_type=args.wandb_job_type,
         wandb_project=args.wandb_project,
         wandb_group=args.wandb_group,
+        wandb_run_name=args.wandb_run_name,
         quiet=args.quiet,
         verbose_fmt=args.verbose_fmt,
         verbose_vars=args.verbose_vars,

--- a/stable_learning_control/algos/pytorch/latc/latc.py
+++ b/stable_learning_control/algos/pytorch/latc/latc.py
@@ -414,6 +414,15 @@ if __name__ == "__main__":
             "(defaults: None)"
         ),
     )
+    parser.add_argument(
+        "--wandb_run_name",
+        type=str,
+        default=None,
+        help=(
+            "the name of the Weights & Biases run (defaults: None, which will be "
+            "set to the experiment name)"
+        ),
+    )
     args = parser.parse_args()
 
     # Setup actor critic arguments.
@@ -442,6 +451,7 @@ if __name__ == "__main__":
         wandb_job_type=args.wandb_job_type,
         wandb_project=args.wandb_project,
         wandb_group=args.wandb_group,
+        wandb_run_name=args.wandb_run_name,
         quiet=args.quiet,
         verbose_fmt=args.verbose_fmt,
         verbose_vars=args.verbose_vars,

--- a/stable_learning_control/algos/pytorch/sac/sac.py
+++ b/stable_learning_control/algos/pytorch/sac/sac.py
@@ -1565,6 +1565,15 @@ if __name__ == "__main__":
             "(defaults: None)"
         ),
     )
+    parser.add_argument(
+        "--wandb_run_name",
+        type=str,
+        default=None,
+        help=(
+            "the name of the Weights & Biases run (defaults: None, which will be "
+            "set to the experiment name)"
+        ),
+    )
     args = parser.parse_args()
 
     # Setup actor critic arguments.
@@ -1593,6 +1602,7 @@ if __name__ == "__main__":
         wandb_job_type=args.wandb_job_type,
         wandb_project=args.wandb_project,
         wandb_group=args.wandb_group,
+        wandb_run_name=args.wandb_run_name,
         tb_log_freq=args.tb_log_freq,
         quiet=args.quiet,
         verbose_fmt=args.verbose_fmt,

--- a/stable_learning_control/algos/tf2/lac/lac.py
+++ b/stable_learning_control/algos/tf2/lac/lac.py
@@ -1651,6 +1651,15 @@ if __name__ == "__main__":
             "(defaults: None)"
         ),
     )
+    parser.add_argument(
+        "--wandb_run_name",
+        type=str,
+        default=None,
+        help=(
+            "the name of the Weights & Biases run (defaults: None, which will be "
+            "set to the experiment name)"
+        ),
+    )
     args = parser.parse_args()
 
     # Setup actor critic arguments.
@@ -1679,6 +1688,7 @@ if __name__ == "__main__":
         wandb_job_type=args.wandb_job_type,
         wandb_project=args.wandb_project,
         wandb_group=args.wandb_group,
+        wandb_run_name=args.wandb_run_name,
         quiet=args.quiet,
         verbose_fmt=args.verbose_fmt,
         verbose_vars=args.verbose_vars,

--- a/stable_learning_control/algos/tf2/latc/latc.py
+++ b/stable_learning_control/algos/tf2/latc/latc.py
@@ -415,6 +415,15 @@ if __name__ == "__main__":
             "(defaults: None)"
         ),
     )
+    parser.add_argument(
+        "--wandb_run_name",
+        type=str,
+        default=None,
+        help=(
+            "the name of the Weights & Biases run (defaults: None, which will be "
+            "set to the experiment name)"
+        ),
+    )
     args = parser.parse_args()
 
     # Setup actor critic arguments.
@@ -443,6 +452,7 @@ if __name__ == "__main__":
         wandb_job_type=args.wandb_job_type,
         wandb_project=args.wandb_project,
         wandb_group=args.wandb_group,
+        wandb_run_name=args.wandb_run_name,
         quiet=args.quiet,
         verbose_fmt=args.verbose_fmt,
         verbose_vars=args.verbose_vars,

--- a/stable_learning_control/algos/tf2/sac/sac.py
+++ b/stable_learning_control/algos/tf2/sac/sac.py
@@ -1495,6 +1495,15 @@ if __name__ == "__main__":
             "(defaults: None)"
         ),
     )
+    parser.add_argument(
+        "--wandb_run_name",
+        type=str,
+        default=None,
+        help=(
+            "the name of the Weights & Biases run (defaults: None, which will be "
+            "set to the experiment name)"
+        ),
+    )
     args = parser.parse_args()
 
     # Setup actor critic arguments.
@@ -1524,6 +1533,7 @@ if __name__ == "__main__":
         wandb_job_type=args.wandb_job_type,
         wandb_project=args.wandb_project,
         wandb_group=args.wandb_group,
+        wandb_run_name=args.wandb_run_name,
         quiet=args.quiet,
         verbose_fmt=args.verbose_fmt,
         verbose_vars=args.verbose_vars,

--- a/stable_learning_control/run.py
+++ b/stable_learning_control/run.py
@@ -49,6 +49,7 @@ SUBSTITUTIONS = {
     "wandb_job_type": "logger_kwargs:wandb_job_type",
     "wandb_proj": "logger_kwargs:wandb_project",
     "wandb_group": "logger_kwargs:wandb_group",
+    "wandb_run_name": "logger_kwargs:wandb_run_name",
     "save_cps": "logger_kwargs:save_checkpoints",
     "tb_log_freq": "logger_kwargs:tb_log_freq",
     "quiet": "logger_kwargs:quiet",


### PR DESCRIPTION
This pull request adds the `wandb_run_name` argument to the CLI. This argument can be used to set the
wandb run name.
