### PR TITLE
feat(lac): add finite-horizon Lyapunov Candidate

### DIFF
--- a/docs/source/usage/algorithms/lac.rst
+++ b/docs/source/usage/algorithms/lac.rst
@@ -117,9 +117,14 @@ Where :math:`L_{target}` is the approximation target received from the `infinite
 
 and :math:`\mathcal{D}` the set of collected transition pairs.
 
-.. note::
+.. important::
     As explained by `Han et al., 2020`_ the sum of cost over a finite time horizon can also be used as the
-    approximation target. This version still needs to be implemented in the SLC framework.
+    approximation target (see `Han et al., 2020` eq (9)):
+
+    .. math::
+        L_{target}(s,a) = \sum_{t}^{t+N} \mathbb{E}_{c_{t}}
+    
+    To use this Lyapunov candidate, supply the LAC algorithm with the ``horizon_length=N`` argument, where ``N`` is the length of the time horizon you want to use.
 
 .. seealso:: 
     The SLC package also contains a LAC implementation using a double Q-Critic (i.e., :ref:`Lyapunov Twin Critic <latc>`).

--- a/sandbox/test_finite_horizon_replay_buffer.py
+++ b/sandbox/test_finite_horizon_replay_buffer.py
@@ -1,11 +1,9 @@
-"""Script used for preforming some quick tests on the TrajectoryBuffer class. This
-buffer was created for a new monte-carlo algorithm we had in mind. The buffer is
-designed to store trajectories of variable length.
+"""Script used for performing some quick tests on the FiniteHorizonReplayBuffer class.
 """
 import gymnasium as gym
 
 # from stable_learning_control.common.buffers import TrajectoryBuffer
-from stable_learning_control.algos.pytorch.common.buffers import TrajectoryBuffer
+from stable_learning_control.algos.common.buffers import FiniteHorizonReplayBuffer
 
 if __name__ == "__main__":
     env = gym.make("stable_gym:CartPoleCost-v1")
@@ -13,43 +11,40 @@ if __name__ == "__main__":
     # Dummy algorithm settings.
     obs_dim = env.observation_space.shape[0]
     act_dim = env.action_space.shape[0]
-    buffer_size = int(1e6)
-    epochs = 10
+    buffer_size = int(200)
+    episodes = 10
     local_steps_per_epoch = 100
 
     # Create Memory Buffer.
-    buffer = TrajectoryBuffer(
+    buffer = FiniteHorizonReplayBuffer(
         obs_dim=obs_dim,
         act_dim=act_dim,
         size=buffer_size,
-        preempt=True,
-        incomplete=True,
+        horizon_size=2,
     )
 
     # Create test dummy data.
     o, _ = env.reset()
     ep_ret, ep_len = 0, 0
-    for epoch in range(epochs):
-        for t in range(local_steps_per_epoch):
+    for episode in range(1, episodes + 1):
+        print(f"Episode {episode}:")
+        d, truncated = False, False
+        t = 0
+        while not d and not truncated:
             # Retrieve data from the environment.
             a = env.action_space.sample()
             o_, r, d, truncated, _ = env.step(a)
+            r = episode + t / 100
 
             # Store data in buffer.
-            buffer.store(o, a, r, o_, d)
+            buffer.store(o, a, r, o_, d, truncated)
 
             # Update obs (critical!)
             o = o_
+            t += 1
 
             # Finish path.
             if d or truncated:
                 print("Environment terminated or truncated. Resetting.")
-                buffer.finish_path()
                 o, _ = env.reset()
-                ep_ret, ep_len = 0, 0
-
-        # Retrieve data from buffer.
-        buffer_data = buffer.get(flat=False)
-
-        # Print data.
-        print(f"Epoch {epoch}:")
+                ep_ret, ep_len, t = 0, 0, 0

--- a/sandbox/test_gym_env.py
+++ b/sandbox/test_gym_env.py
@@ -7,44 +7,43 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 RANDOM_STEP = True
-ENV_NAME = "stable_gym:Oscillator-v1"
+# ENV_NAME = "stable_gym:Oscillator-v1"
 # ENV_NAME = "stable_gym:Ex3EKF-v1"
-# ENV_NAME = "stable_Gym:CartPoleCost-v0"
+ENV_NAME = "stable_gym:CartPoleCost-v1"
 # ENV_NAME = "PandaReach-v1"
 
 if __name__ == "__main__":
-    env = gym.make(ENV_NAME)
+    env = gym.make(ENV_NAME, render_mode="human")
 
-    # Take T steps in the environment.
-    T = 1000
-    tau = 0.1
+    # Retrieve time step.
+    tau = env.dt if hasattr(env, "dt") else env.tau if hasattr(env, "tau") else 0.01
+
+    # Take one episode in the environment.
+    d, truncated, t = False, False, 0
     path = []
-    t1 = []
-    s = env.reset()
-    print(f"Taking {T} steps in the Cartpole environment.")
-    for i in range(int(T / tau)):
-        action = (
+    time = []
+    o, _ = env.reset()
+    print(f"Performing 1 epsisode in the '{ENV_NAME}' environment.")
+    while not d and not truncated:
+        a = (
             env.action_space.sample()
             if RANDOM_STEP
             else np.zeros(env.action_space.shape)
         )
-        s, r, done, info = env.step(action)
-        try:
-            env.render()
-        except NotImplementedError:
-            pass
-        path.append(s)
-        t1.append(i * tau)
-    print("Finished Cartpole environment simulation.")
+        o, r, d, truncated, _ = env.step(a)
+        t += tau
+        path.append(o)
+        time.append(t)
+    print(f"Finished '{ENV_NAME}' environment simulation.")
 
     # Plot results.
     print("Plot results.")
     fig = plt.figure(figsize=(9, 6))
     ax = fig.add_subplot(111)
-    ax.plot(t1, np.array(path)[:, 0], color="orange", label="x")
-    ax.plot(t1, np.array(path)[:, 1], color="magenta", label="x_dot")
-    ax.plot(t1, np.array(path)[:, 2], color="sienna", label="theta")
-    ax.plot(t1, np.array(path)[:, 3], color="blue", label="theta_dot1")
+    ax.plot(time, np.array(path)[:, 0], color="orange", label="x")
+    ax.plot(time, np.array(path)[:, 1], color="magenta", label="x_dot")
+    ax.plot(time, np.array(path)[:, 2], color="sienna", label="theta")
+    ax.plot(time, np.array(path)[:, 3], color="blue", label="theta_dot1")
 
     handles, labels = ax.get_legend_handles_labels()
     ax.legend(handles, labels, loc=2, fancybox=False, shadow=False)

--- a/sandbox/test_replay_buffer.py
+++ b/sandbox/test_replay_buffer.py
@@ -1,11 +1,9 @@
-"""Script used for preforming some quick tests on the TrajectoryBuffer class. This
-buffer was created for a new monte-carlo algorithm we had in mind. The buffer is
-designed to store trajectories of variable length.
+"""Script used for performing some quick tests on the ReplayBuffer class.
 """
 import gymnasium as gym
 
 # from stable_learning_control.common.buffers import TrajectoryBuffer
-from stable_learning_control.algos.pytorch.common.buffers import TrajectoryBuffer
+from stable_learning_control.algos.pytorch.common.buffers import ReplayBuffer
 
 if __name__ == "__main__":
     env = gym.make("stable_gym:CartPoleCost-v1")
@@ -13,24 +11,24 @@ if __name__ == "__main__":
     # Dummy algorithm settings.
     obs_dim = env.observation_space.shape[0]
     act_dim = env.action_space.shape[0]
-    buffer_size = int(1e6)
-    epochs = 10
+    buffer_size = int(200)
+    episodes = 10
     local_steps_per_epoch = 100
 
     # Create Memory Buffer.
-    buffer = TrajectoryBuffer(
+    buffer = ReplayBuffer(
         obs_dim=obs_dim,
         act_dim=act_dim,
         size=buffer_size,
-        preempt=True,
-        incomplete=True,
     )
 
     # Create test dummy data.
     o, _ = env.reset()
     ep_ret, ep_len = 0, 0
-    for epoch in range(epochs):
-        for t in range(local_steps_per_epoch):
+    for episode in range(1, episodes + 1):
+        print(f"Episode {episode}:")
+        d, truncated = False, False
+        while not d and not truncated:
             # Retrieve data from the environment.
             a = env.action_space.sample()
             o_, r, d, truncated, _ = env.step(a)
@@ -44,12 +42,5 @@ if __name__ == "__main__":
             # Finish path.
             if d or truncated:
                 print("Environment terminated or truncated. Resetting.")
-                buffer.finish_path()
                 o, _ = env.reset()
                 ep_ret, ep_len = 0, 0
-
-        # Retrieve data from buffer.
-        buffer_data = buffer.get(flat=False)
-
-        # Print data.
-        print(f"Epoch {epoch}:")

--- a/stable_learning_control/algos/pytorch/common/buffers.py
+++ b/stable_learning_control/algos/pytorch/common/buffers.py
@@ -3,6 +3,9 @@
 import torch
 
 from stable_learning_control.algos.common.buffers import (
+    FiniteHorizonReplayBuffer as CommonFiniteHorizonReplayBuffer,
+)
+from stable_learning_control.algos.common.buffers import (
     ReplayBuffer as CommonReplayBuffer,
 )
 from stable_learning_control.algos.common.buffers import (
@@ -36,8 +39,52 @@ class ReplayBuffer(CommonReplayBuffer):
         """Retrieve a batch of experiences from buffer.
 
         Args:
-            *args: All args to pass to the :meth:`~ReplayBuffer.get` parent method.
-            **kwargs: All kwargs to pass to the :meth:`~ReplayBuffer.get` parent method.
+            *args: All args to pass to the :meth:`~ReplayBuffer.sample_batch` parent
+                method.
+            **kwargs: All kwargs to pass to the :meth:`~ReplayBuffer.sample_batch`
+                parent method.
+
+        Returns:
+            dict: A batch of experiences.
+        """
+        return np_to_torch(
+            super().sample_batch(*args, **kwargs),
+            dtype=torch.float32,
+            device=self.device,
+        )  # Make sure output is a torch tensor.
+
+
+class FiniteHorizonReplayBuffer(CommonFiniteHorizonReplayBuffer):
+    """Wrapper around the general FIFO
+    :obj:`~stable_learning_control.common.buffers.FiniteHorizonReplayBuffer` which makes
+    sure a :obj:`torch.tensor` is returned when sampling.
+
+    Attributes:
+        device (str): The device the experiences are placed on (CPU or GPU).
+    """
+
+    def __init__(self, device="cpu", *args, **kwargs):
+        """Initialise the FiniteHorizonReplayBuffer object.
+
+        Args:
+            device (str, optional): The computational device to put the sampled
+                experiences on.
+            *args: All args to pass to the :class:`FiniteHorizonReplayBuffer` parent
+                class.
+            **kwargs: All kwargs to pass to the class:`FiniteHorizonReplayBuffer` parent
+                class.
+        """
+        self.device = device
+        super().__init__(*args, **kwargs)
+
+    def sample_batch(self, *args, **kwargs):
+        """Retrieve a batch of experiences from buffer.
+
+        Args:
+            *args: All args to pass to the
+                :meth:`~FiniteHorizonReplayBuffer.sample_batch` parent method.
+            **kwargs: All kwargs to pass to the :meth:`~ReplayBuffer.sample_batch`
+                parent method.
 
         Returns:
             dict: A batch of experiences.

--- a/stable_learning_control/algos/pytorch/latc/latc.py
+++ b/stable_learning_control/algos/pytorch/latc/latc.py
@@ -305,6 +305,15 @@ if __name__ == "__main__":
         help="replay buffer size (default: 1e6)",
     )
     parser.add_argument(
+        "--horizon_length",
+        type=int,
+        default=0,
+        help=(
+            "length of the finite-horizon used for the Lyapunov Critic target ( "
+            "Default: 0, meaning the infinite-horizon bellman backup is used)."
+        ),
+    )
+    parser.add_argument(
         "--seed", "-s", type=int, default=0, help="the random seed (default: 0)"
     )
     parser.add_argument(
@@ -492,6 +501,7 @@ if __name__ == "__main__":
         lr_decay_ref=args.lr_decay_ref,
         batch_size=args.batch_size,
         replay_size=args.replay_size,
+        horizon_length=args.horizon_length,
         seed=args.seed,
         save_freq=args.save_freq,
         device=args.device,

--- a/stable_learning_control/algos/pytorch/sac/sac.py
+++ b/stable_learning_control/algos/pytorch/sac/sac.py
@@ -885,9 +885,9 @@ def sac(
     Returns:
         (tuple): tuple containing:
 
-                - policy (:class:`SAC`): The trained actor-critic policy.
-                - replay_buffer (:class:`~stable_learning_control.algos.pytorch.common.buffers.ReplayBuffer`): The
-                  replay buffer used during training.
+            -   policy (:class:`SAC`): The trained actor-critic policy.
+            -   replay_buffer (union[:class:`~stable_learning_control.algos.common.buffers.ReplayBuffer`, :class:`~stable_learning_control.algos.common.buffers.FiniteHorizonReplayBuffer`]):
+                The replay buffer used during training.
     """  # noqa: E501
     validate_args(**locals())
 

--- a/stable_learning_control/algos/tf2/latc/latc.py
+++ b/stable_learning_control/algos/tf2/latc/latc.py
@@ -306,6 +306,15 @@ if __name__ == "__main__":
         help="replay buffer size (default: 1e6)",
     )
     parser.add_argument(
+        "--horizon_length",
+        type=int,
+        default=0,
+        help=(
+            "length of the finite-horizon used for the Lyapunov Critic target ( "
+            "Default: 0, meaning the infinite-horizon bellman backup is used)."
+        ),
+    )
+    parser.add_argument(
         "--seed", "-s", type=int, default=0, help="the random seed (default: 0)"
     )
     parser.add_argument(
@@ -492,6 +501,7 @@ if __name__ == "__main__":
         lr_decay_ref=args.lr_decay_ref,
         batch_size=args.batch_size,
         replay_size=args.replay_size,
+        horizon_length=args.horizon_length,
         seed=args.seed,
         save_freq=args.save_freq,
         device=args.device,

--- a/stable_learning_control/algos/tf2/sac/sac.py
+++ b/stable_learning_control/algos/tf2/sac/sac.py
@@ -818,9 +818,9 @@ def sac(
     Returns:
         (tuple): tuple containing:
 
-                - policy (:class:`SAC`): The trained actor-critic policy.
-                - replay_buffer (:class:`~stable_learning_control.algos.common.buffers.ReplayBuffer`): The
-                  replay buffer used during training.
+            -   policy (:class:`SAC`): The trained actor-critic policy.
+            -   replay_buffer (union[:class:`~stable_learning_control.algos.common.buffers.ReplayBuffer`, :class:`~stable_learning_control.algos.common.buffers.FiniteHorizonReplayBuffer`]):
+                The replay buffer used during training.
     """  # noqa: E501
     validate_args(**locals())
 


### PR DESCRIPTION
This pull request adds the sum of cost over a finite horizon as the Lyapunov Candidate. For more
information see [Han et al. 2020](https://arxiv.org/abs/2004.14288).

```math
L_{target}(s,a) = \sum_{t}^{t+N} \mathbb{E}_{c_{t}}
```
