### PR TITLE
docs: add ros-gazebo-gym positive reward comment

### DIFF
--- a/docs/source/usage/algorithms.rst
+++ b/docs/source/usage/algorithms.rst
@@ -22,7 +22,8 @@ Stable Agents
    :gymnasium:`gymnasium <>` environments, the stable RL agents require a positive definite
    cost function to guarantee stability (and robustness). Several custom environments with
    positive definite cost functions can be found in the :stable-gym:`stable-gym <>` and
-   :ros-gazebo-gym:`ros-gazebo-gym <>` packages.
+   :ros-gazebo-gym:`ros-gazebo-gym <>` packages. When using the latter, make sure to set
+   ``positive_reward`` to ``True``.
 
 The SLC package currently contains the following theoretically stable RL algorithms:
 

--- a/docs/source/usage/installation.rst
+++ b/docs/source/usage/installation.rst
@@ -174,7 +174,7 @@ environments which are compatible with the stable algorithms:
 * :stable-gym:`stable-gym <>`: Several gymnasium environments with cost functions compatible with (stable) 
   RL agents (i.e. positive definite). 
 * :ros-gazebo-gym:`ros-gazebo-gym packages <>`: A framework for training RL algorithms on ROS Gazebo 
-  robots that can use positive definite cost functions.
+  robots that can return positive definite cost functions (i.e. when ``positive_reward`` is set to ``True``).
 
 Please refer to the documentation of these packages for more information on installing
 these environments. After you install these environments or any custom environment, you


### PR DESCRIPTION
This commit adds a comment that lets users know that they should set the
``positive_reward`` argument to ``True`` when they use the
[ros-gazebo-gym](https://github.com/rickstaa/ros-gazebo-gym) package
with the SLC package.
