### PR TITLE
ci(docs): fix documentation latex formulas

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,13 @@ jobs:
           cache: "pip"
           cache-dependency-path: pyproject.toml
       - name: Install system dependencies
-        run: sudo apt-get update; sudo apt-get install libopenmpi-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libopenmpi-dev \
+            texlive \
+            texlive-latex-extra \
+            texlive-science
       - name: Install dependencies
         run: |
           pip install .[docs]

--- a/docs/source/dev/doc_dev.rst
+++ b/docs/source/dev/doc_dev.rst
@@ -19,7 +19,7 @@ To install the `LATEX`_ system dependencies, you can use the following command:
 
 .. code-block:: bash
 
-    sudo apt-get install texlive-latex-extra texlive-science
+    sudo apt-get install texlive texlive-latex-extra texlive-science
 
 .. _LATEX: https://www.tug.org/texlive/
 .. _sphinx: https://www.sphinx-doc.org/en/master


### PR DESCRIPTION
This pull request attempts to fix the Latex formulas that appear broken when building the documentation inside the docs github action.
