### PR TITLE
refactor(experiments): apply han2020 final learning rates

### DIFF
--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment.yml
@@ -30,9 +30,9 @@ lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
 lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment_seed234.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment_seed234.yml
@@ -30,9 +30,9 @@ lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
 lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment_seed3658.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment_seed3658.yml
@@ -30,9 +30,9 @@ lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
 lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment_seed48104.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment_seed48104.yml
@@ -30,9 +30,9 @@ lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
 lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment_seed567.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment_seed567.yml
@@ -30,9 +30,9 @@ lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
 lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment_seed78456.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_cartpole_cost_alpha3_tune_experiment_seed78456.yml
@@ -30,9 +30,9 @@ lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
 lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment_seed234.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment_seed234.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment_seed3658.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment_seed3658.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment_seed48104.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment_seed48104.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment_seed567.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment_seed567.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment_seed78456.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_fetch_reach_alpha3_tune_experiment_seed78456.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "3.3333333e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment_seed234.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment_seed234.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment_seed3658.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment_seed3658.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment_seed48104.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment_seed48104.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment_seed567.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment_seed567.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment_seed78456.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_alpha3_tune_experiment_seed78456.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed234.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed234.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed3658.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed3658.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed48104.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed48104.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed567.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed567.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"

--- a/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed78456.yml
+++ b/experiments/staa_et_al_2024/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed78456.yml
@@ -29,10 +29,10 @@ lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
 lr_labda: "3e-4"
-lr_a_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_c_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_alpha_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
-lr_labda_final: "1e-10"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
+lr_labda_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_a_decay_type: "linear"
 lr_c_decay_type: "linear"
 lr_alpha_decay_type: "linear"


### PR DESCRIPTION
This commit ensure that the final learning rates in the experimental configs
of the `staa_et_al_2024` experiment align with those found in the
original codebase of [Han et
al.](https://github.com/hithmh/Actor-critic-with-stability-guarantee).