### PR TITLE
chore(exp): fix CompOscillator learning length

### DIFF
--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed26000.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed26000.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100
@@ -41,7 +41,7 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 858762 # 388389  # NOTE: Using 5 seeds for tuning.
+seed: 26000 # 49672 858762 388389  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
 wandb_group: "han2020_reproduction_extra_seeds"

--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed388389.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed388389.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_extra_long
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 78456 48104 567 3658 234  # NOTE: Using 5 seeds for tuning.
+seed: 388389  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_extra_long"
+wandb_group: "han2020_reproduction_extra_seeds"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed408660.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed408660.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_lr_lambda_check
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -20,7 +20,7 @@ update_after: 1000
 steps_per_update: 80
 num_test_episodes: 10
 alpha: 2.0
-alpha3: 0.1 0.3 1.0  # NOTE: Tuning alpha3.
+alpha3: 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5  # NOTE: Tuning alpha3.
 labda: 0.99  # NOTE: Decreased from 1.0 to 0.99 for stability.
 # gamma: 0.995   # NOTE: Not used for finite horizon tasks.
 polyak: 0.995
@@ -28,7 +28,7 @@ adaptive_temperature: True
 lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
-lr_labda: "1e-4"
+lr_labda: "3e-4"
 lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 234  # NOTE: Using 5 seeds for tuning.
+seed: 408660 # 26000 49672 858762 388389  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_lr_lambda_check"
+wandb_group: "han2020_reproduction_extra_seeds"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed49672.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed49672.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed858762.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed858762.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_lr_lambda_check
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -20,7 +20,7 @@ update_after: 1000
 steps_per_update: 80
 num_test_episodes: 10
 alpha: 2.0
-alpha3: 0.1 0.3 1.0  # NOTE: Tuning alpha3.
+alpha3: 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5  # NOTE: Tuning alpha3.
 labda: 0.99  # NOTE: Decreased from 1.0 to 0.99 for stability.
 # gamma: 0.995   # NOTE: Not used for finite horizon tasks.
 polyak: 0.995
@@ -28,7 +28,7 @@ adaptive_temperature: True
 lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
-lr_labda: "1e-4"
+lr_labda: "3e-4"
 lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 234  # NOTE: Using 5 seeds for tuning.
+seed: 858762 # 388389  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_lr_lambda_check"
+wandb_group: "han2020_reproduction_extra_seeds"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seeds.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seeds.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed26000_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed26000_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_lr_lambda_check
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 98
+epochs: 49
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100
@@ -20,7 +20,7 @@ update_after: 1000
 steps_per_update: 80
 num_test_episodes: 10
 alpha: 2.0
-alpha3: 0.1 0.3 1.0  # NOTE: Tuning alpha3.
+alpha3: 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5  # NOTE: Tuning alpha3.
 labda: 0.99  # NOTE: Decreased from 1.0 to 0.99 for stability.
 # gamma: 0.995   # NOTE: Not used for finite horizon tasks.
 polyak: 0.995
@@ -28,7 +28,7 @@ adaptive_temperature: True
 lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
-lr_labda: "1e-4"
+lr_labda: "3e-4"
 lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 234  # NOTE: Using 5 seeds for tuning.
+seed: 26000 # 49672 858762 388389  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_lr_lambda_check"
+wandb_group: "han2020_reproduction_extra_seeds_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed388389_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed388389_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_lr_lambda_check
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 98
+epochs: 49
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100
@@ -20,7 +20,7 @@ update_after: 1000
 steps_per_update: 80
 num_test_episodes: 10
 alpha: 2.0
-alpha3: 0.1 0.3 1.0  # NOTE: Tuning alpha3.
+alpha3: 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5  # NOTE: Tuning alpha3.
 labda: 0.99  # NOTE: Decreased from 1.0 to 0.99 for stability.
 # gamma: 0.995   # NOTE: Not used for finite horizon tasks.
 polyak: 0.995
@@ -28,7 +28,7 @@ adaptive_temperature: True
 lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
-lr_labda: "1e-4"
+lr_labda: "3e-4"
 lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 234  # NOTE: Using 5 seeds for tuning.
+seed: 388389  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_lr_lambda_check"
+wandb_group: "han2020_reproduction_extra_seeds_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed408660_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed408660_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_extra_long
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 98
+epochs: 49
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 48104 # 567 3658 234  # NOTE: Using 5 seeds for tuning.
+seed: 408660 # 26000 49672 858762 388389  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_extra_long"
+wandb_group: "han2020_reproduction_extra_seeds_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed49672_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed49672_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 388389  # NOTE: Using 5 seeds for tuning.
+seed: 49672 # 858762 388389  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_extra_seeds"
+wandb_group: "han2020_reproduction_extra_seeds_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed858762_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seed858762_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_lr_lambda_check
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 98
+epochs: 49
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100
@@ -20,7 +20,7 @@ update_after: 1000
 steps_per_update: 80
 num_test_episodes: 10
 alpha: 2.0
-alpha3: 0.1 0.3 1.0  # NOTE: Tuning alpha3.
+alpha3: 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5  # NOTE: Tuning alpha3.
 labda: 0.99  # NOTE: Decreased from 1.0 to 0.99 for stability.
 # gamma: 0.995   # NOTE: Not used for finite horizon tasks.
 polyak: 0.995
@@ -28,7 +28,7 @@ adaptive_temperature: True
 lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
-lr_labda: "1e-4"
+lr_labda: "3e-4"
 lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 234  # NOTE: Using 5 seeds for tuning.
+seed: 858762 # 388389  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_lr_lambda_check"
+wandb_group: "han2020_reproduction_extra_seeds_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seeds_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/extra_seeds/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_extra_seeds_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_extra_long
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 98
+epochs: 49
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 567 # 3658 234  # NOTE: Using 5 seeds for tuning.
+seed: 408660 26000 49672 858762 388389  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_extra_long"
+wandb_group: "han2020_reproduction_extra_seeds_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed234.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed234.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed3658.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed3658.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed48104.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed48104.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed567.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed567.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed78456.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed78456.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/lambda_lr_check/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_lambda_lr_lambda_check.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/lambda_lr_check/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_lambda_lr_lambda_check.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/lambda_lr_check/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed3658_lr_lambda_check.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/lambda_lr_check/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed3658_lr_lambda_check.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/lambda_lr_check/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed48104_lr_lambda_check.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/lambda_lr_check/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed48104_lr_lambda_check.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/lambda_lr_check/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed567_lr_lambda_check.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/lambda_lr_check/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed567_lr_lambda_check.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/lambda_lr_check/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed78456_lr_lambda_check.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/lambda_lr_check/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed78456_lr_lambda_check.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed234_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed234_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_lr_lambda_check
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 98
+epochs: 49
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100
@@ -20,7 +20,7 @@ update_after: 1000
 steps_per_update: 80
 num_test_episodes: 10
 alpha: 2.0
-alpha3: 0.1 0.3 1.0  # NOTE: Tuning alpha3.
+alpha3: 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1.0 1.1 1.2 1.3 1.4 1.5  # NOTE: Tuning alpha3.
 labda: 0.99  # NOTE: Decreased from 1.0 to 0.99 for stability.
 # gamma: 0.995   # NOTE: Not used for finite horizon tasks.
 polyak: 0.995
@@ -28,7 +28,7 @@ adaptive_temperature: True
 lr_a: "1e-4"
 lr_c: "3e-4"
 lr_alpha: "1e-4"
-lr_labda: "1e-4"
+lr_labda: "3e-4"
 lr_a_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_c_final: "3e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
 lr_alpha_final: "1e-9"  # NOTE: Not in Han et al. 2020, but aligned with original code.
@@ -44,5 +44,5 @@ horizon_length: 5
 seed: 234  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_lr_lambda_check"
+wandb_group: "han2020_reproduction_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed3658_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed3658_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_extra_long
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 98
+epochs: 49
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 78456 # 48104 567 3658 234  # NOTE: Using 5 seeds for tuning.
+seed: 3658 # 234  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_extra_long"
+wandb_group: "han2020_reproduction_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed48104_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed48104_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_extra_long
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 98
+epochs: 49
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 3658 # 234  # NOTE: Using 5 seeds for tuning.
+seed: 48104 # 567 3658 234  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_extra_long"
+wandb_group: "han2020_reproduction_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed567_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed567_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_extra_long
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 98
+epochs: 49
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 234  # NOTE: Using 5 seeds for tuning.
+seed: 567 # 3658 234  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_extra_long"
+wandb_group: "han2020_reproduction_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed78456_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed78456_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 408660 # 26000 49672 858762 388389  # NOTE: Using 5 seeds for tuning.
+seed: 78456 # 48104 567 3658 234  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_extra_seeds"
+wandb_group: "han2020_reproduction_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_short.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/short/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_short.yml
@@ -1,5 +1,5 @@
 alg_name: lac
-exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp
+exp_name: han2020_reproduction_lac_oscillator_complicated_alpha3_tune_exp_short
 env_name: "stable_gym:OscillatorComplicated-v1"
 ac_kwargs:
   hidden_sizes:
@@ -41,8 +41,8 @@ lr_decay_ref: "step"
 batch_size: 256
 replay_size: "int(1e6)"
 horizon_length: 5
-seed: 26000 # 49672 858762 388389  # NOTE: Using 5 seeds for tuning.
+seed: 78456 48104 567 3658 234  # NOTE: Using 5 seeds for tuning.
 save_freq: 10
 use_wandb: True
-wandb_group: "han2020_reproduction_extra_seeds"
+wandb_group: "han2020_reproduction_short"
 device: "gpu:1"

--- a/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed234_small_critic.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed234_small_critic.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed3658_small_critic.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed3658_small_critic.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed48104_small_critic.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed48104_small_critic.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed567_small_critic.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed567_small_critic.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed78456_small_critic.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_seed78456_small_critic.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100

--- a/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_small_critic.yml
+++ b/experiments/staa_et_al_2024/comp_oscillator/small_critic/han2020_reproduction_lac_oscillator_complicated_alpha3_tune_experiment_small_critic.yml
@@ -12,7 +12,7 @@ ac_kwargs:
     actor: "nn.ReLU"
 opt_type: "minimize"
 max_ep_len: 400
-epochs: 49
+epochs: 98
 steps_per_epoch: 2048
 start_steps: 0
 update_every: 100


### PR DESCRIPTION
This commit changed the CompOscillator learning length from 1e5 to 2e5.
This was done to deal with an inconsistency in Han et al.'s reserach.
